### PR TITLE
Add monthly income management and category editor

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { DashboardView } from './views/DashboardView';
 import { BalanceSheetView } from './views/BalanceSheetView';
 import { TrendAnalysisView } from './views/TrendAnalysisView';
 import { SmartBudgetingView } from './views/SmartBudgetingView';
+import { IncomeManagementView } from './views/IncomeManagementView';
 import { RecurringExpensesView } from './views/RecurringExpensesView';
 import { GoalSimulatorView } from './views/GoalSimulatorView';
 import { InsightsView } from './views/InsightsView';
@@ -69,6 +70,9 @@ export default function App() {
           <NavLink to="/budgeting" className={navLinkClass}>
             Smart Budgeting
           </NavLink>
+          <NavLink to="/income" className={navLinkClass}>
+            Income & Categories
+          </NavLink>
           <NavLink to="/recurring" className={navLinkClass}>
             Recurring Expenses Hub
           </NavLink>
@@ -88,6 +92,7 @@ export default function App() {
             <Route path="/balance" element={<BalanceSheetView />} />
             <Route path="/trends" element={<TrendAnalysisView />} />
             <Route path="/budgeting" element={<SmartBudgetingView />} />
+            <Route path="/income" element={<IncomeManagementView />} />
             <Route path="/recurring" element={<RecurringExpensesView />} />
             <Route path="/goals" element={<GoalSimulatorView />} />
             <Route path="/insights" element={<InsightsView />} />

--- a/src/services/dataAggregationService.ts
+++ b/src/services/dataAggregationService.ts
@@ -9,7 +9,8 @@ import type {
   Transaction,
   WealthAcceleratorMetrics,
   Insight,
-  Goal
+  Goal,
+  MonthlyIncome
 } from '../types';
 import { persistSnapshot } from './indexedDbService';
 import { generateInsights } from './insightsEngine';
@@ -20,6 +21,7 @@ interface AggregationOptions {
   manualAccounts?: Account[];
   manualTransactions?: Transaction[];
   manualCategories?: Category[];
+  manualMonthlyIncomes?: MonthlyIncome[];
 }
 
 export class DataAggregationService {
@@ -41,14 +43,27 @@ export class DataAggregationService {
     const plannedExpenses = this.generatePlannedExpenses(categories);
     const recurringExpenses = this.generateRecurringExpenses(categories);
     const goals = this.generateGoals(categories);
+    const monthlyIncomes = this.mergeMonthlyIncomes(
+      this.generateMonthlyIncomes(categories),
+      options.manualMonthlyIncomes ?? []
+    );
 
-    const wealthMetrics = simulateWealthAccelerator(accounts, transactions, goals, recurringExpenses);
-    const insights = generateInsights({ accounts, transactions, recurringExpenses, plannedExpenses, goals, categories });
+    const wealthMetrics = simulateWealthAccelerator(accounts, transactions, goals, recurringExpenses, monthlyIncomes);
+    const insights = generateInsights({
+      accounts,
+      transactions,
+      recurringExpenses,
+      plannedExpenses,
+      goals,
+      categories,
+      monthlyIncomes
+    });
 
     const snapshot: FinancialSnapshot = {
       accounts,
       categories,
       transactions,
+      monthlyIncomes,
       plannedExpenses,
       recurringExpenses,
       goals,
@@ -127,6 +142,14 @@ export class DataAggregationService {
     return Array.from(map.values());
   }
 
+  private mergeMonthlyIncomes(base: MonthlyIncome[], manual: MonthlyIncome[]): MonthlyIncome[] {
+    const map = new Map(base.map((income) => [income.id, income]));
+    for (const income of manual) {
+      map.set(income.id, income);
+    }
+    return Array.from(map.values());
+  }
+
   private categorizeTransactions(transactions: Transaction[], categories: Category[]): Transaction[] {
     return transactions.map((transaction) => {
       if (transaction.categoryId) return transaction;
@@ -177,6 +200,20 @@ export class DataAggregationService {
         currency: 'INR',
         isEstimated: false,
         nextDueDate: new Date().toISOString()
+      }
+    ];
+  }
+
+  private generateMonthlyIncomes(categories: Category[]): MonthlyIncome[] {
+    const salaryCategory = categories.find((cat) => cat.type === 'income');
+    return [
+      {
+        id: uuid(),
+        source: 'Salary - Apex Manufacturing',
+        amount: 185000,
+        categoryId: salaryCategory?.id ?? categories[0].id,
+        receivedOn: new Date().toISOString(),
+        notes: 'Credited via payroll'
       }
     ];
   }

--- a/src/services/indexedDbService.test.ts
+++ b/src/services/indexedDbService.test.ts
@@ -14,8 +14,8 @@ const baseSnapshot: FinancialSnapshot = {
       name: 'Checking',
       balance: 50000,
       type: 'bank',
-      institution: 'Sample Bank',
-      lastUpdated: new Date().toISOString(),
+      currency: 'INR',
+      institutionId: 'sample-bank',
       isManual: true
     }
   ],
@@ -28,10 +28,19 @@ const baseSnapshot: FinancialSnapshot = {
       id: 'txn-1',
       accountId: 'acct-1',
       amount: 50000,
+      currency: 'INR',
       date: new Date().toISOString(),
       description: 'Monthly salary',
+      categoryId: 'cat-1'
+    }
+  ],
+  monthlyIncomes: [
+    {
+      id: 'custom-income-1',
+      source: 'Salary',
+      amount: 50000,
       categoryId: 'cat-1',
-      isAiCategorised: true
+      receivedOn: new Date().toISOString()
     }
   ],
   plannedExpenses: [],
@@ -58,7 +67,7 @@ describe('indexedDbService encryption', () => {
   it('stores encrypted payloads in the snapshot store', async () => {
     await persistSnapshot(baseSnapshot);
 
-    const db = await openDB(DB_NAME, 2);
+    const db = await openDB(DB_NAME, 3);
     const record = await db.get('snapshots', 'singleton');
 
     expect(record?.payload).toBeDefined();
@@ -69,18 +78,22 @@ describe('indexedDbService encryption', () => {
   });
 
   it('migrates legacy stores into an encrypted snapshot and clears plain text', async () => {
-    const db = await openDB(DB_NAME, 2);
+    const db = await openDB(DB_NAME, 3);
     await db.put('accounts', baseSnapshot.accounts[0]);
     await db.put('categories', baseSnapshot.categories[0]);
     await db.put('transactions', baseSnapshot.transactions[0]);
+    await db.put('monthlyIncomes', baseSnapshot.monthlyIncomes[0]);
     await db.put('wealthMetrics', { id: 'singleton', ...baseSnapshot.wealthMetrics });
 
     const snapshot = await loadSnapshot();
     expect(snapshot?.accounts).toHaveLength(1);
     expect(snapshot?.accounts[0].name).toBe('Checking');
+    expect(snapshot?.monthlyIncomes).toHaveLength(1);
 
     const legacyAccounts = await db.getAll('accounts');
     expect(legacyAccounts).toHaveLength(0);
+    const legacyIncomes = await db.getAll('monthlyIncomes');
+    expect(legacyIncomes).toHaveLength(0);
 
     const encryptedRecord = await db.get('snapshots', 'singleton');
     expect(encryptedRecord?.payload ?? '').not.toContain('Sample Bank');

--- a/src/services/indexedDbService.ts
+++ b/src/services/indexedDbService.ts
@@ -5,6 +5,7 @@ import type {
   FinancialSnapshot,
   Goal,
   Insight,
+  MonthlyIncome,
   PlannedExpenseItem,
   RecurringExpense,
   Transaction,
@@ -13,13 +14,14 @@ import type {
 } from '../types';
 
 const DB_NAME = 'wealth-accelerator-db';
-const DB_VERSION = 2;
+const DB_VERSION = 3;
 const SNAPSHOT_STORE = 'snapshots';
 
 export type StoreName =
   | 'accounts'
   | 'categories'
   | 'transactions'
+  | 'monthlyIncomes'
   | 'plannedExpenses'
   | 'recurringExpenses'
   | 'goals'
@@ -36,6 +38,7 @@ const LEGACY_STORES: StoreName[] = [
   'accounts',
   'categories',
   'transactions',
+  'monthlyIncomes',
   'plannedExpenses',
   'recurringExpenses',
   'goals',
@@ -58,6 +61,9 @@ async function getDb() {
         }
         if (!database.objectStoreNames.contains('transactions')) {
           database.createObjectStore('transactions', { keyPath: 'id' });
+        }
+        if (!database.objectStoreNames.contains('monthlyIncomes')) {
+          database.createObjectStore('monthlyIncomes', { keyPath: 'id' });
         }
         if (!database.objectStoreNames.contains('plannedExpenses')) {
           database.createObjectStore('plannedExpenses', { keyPath: 'id' });
@@ -130,23 +136,35 @@ export async function loadSnapshot(): Promise<FinancialSnapshot | null> {
 }
 
 async function loadLegacySnapshot(): Promise<FinancialSnapshot | null> {
-  const [accounts, categories, transactions, plannedExpenses, recurringExpenses, goals, insights, wealthMetrics, connections] =
-    await Promise.all([
-      getAll<Account>('accounts'),
-      getAll<Category>('categories'),
-      getAll<Transaction>('transactions'),
-      getAll<PlannedExpenseItem>('plannedExpenses'),
-      getAll<RecurringExpense>('recurringExpenses'),
-      getAll<Goal>('goals'),
-      getAll<Insight>('insights'),
-      getAll<WealthAcceleratorMetrics & { id: string }>('wealthMetrics'),
-      getAll<FinancialInstitutionConnection>('connections')
-    ]);
+  const [
+    accounts,
+    categories,
+    transactions,
+    monthlyIncomes,
+    plannedExpenses,
+    recurringExpenses,
+    goals,
+    insights,
+    wealthMetrics,
+    connections
+  ] = await Promise.all([
+    getAll<Account>('accounts'),
+    getAll<Category>('categories'),
+    getAll<Transaction>('transactions'),
+    getAll<MonthlyIncome>('monthlyIncomes'),
+    getAll<PlannedExpenseItem>('plannedExpenses'),
+    getAll<RecurringExpense>('recurringExpenses'),
+    getAll<Goal>('goals'),
+    getAll<Insight>('insights'),
+    getAll<WealthAcceleratorMetrics & { id: string }>('wealthMetrics'),
+    getAll<FinancialInstitutionConnection>('connections')
+  ]);
 
   if (
     accounts.length === 0 &&
     categories.length === 0 &&
     transactions.length === 0 &&
+    monthlyIncomes.length === 0 &&
     plannedExpenses.length === 0 &&
     recurringExpenses.length === 0 &&
     goals.length === 0 &&
@@ -168,6 +186,7 @@ async function loadLegacySnapshot(): Promise<FinancialSnapshot | null> {
     accounts,
     categories,
     transactions,
+    monthlyIncomes,
     plannedExpenses,
     recurringExpenses,
     goals,
@@ -187,6 +206,7 @@ export async function exportSnapshot(): Promise<Blob> {
     accounts: [],
     categories: [],
     transactions: [],
+    monthlyIncomes: [],
     plannedExpenses: [],
     recurringExpenses: [],
     goals: [],

--- a/src/services/insightsEngine.ts
+++ b/src/services/insightsEngine.ts
@@ -6,7 +6,8 @@ import type {
   Insight,
   PlannedExpenseItem,
   RecurringExpense,
-  Transaction
+  Transaction,
+  MonthlyIncome
 } from '../types';
 
 interface InsightInput {
@@ -16,14 +17,17 @@ interface InsightInput {
   plannedExpenses: PlannedExpenseItem[];
   goals: Goal[];
   categories: Category[];
+  monthlyIncomes: MonthlyIncome[];
 }
 
 export function generateInsights(input: InsightInput): Insight[] {
   const insights: Insight[] = [];
 
-  const totalIncome = input.transactions
+  const totalIncomeFromTransactions = input.transactions
     .filter((txn) => txn.amount > 0)
     .reduce((sum, txn) => sum + txn.amount, 0);
+  const recurringIncome = input.monthlyIncomes.reduce((sum, income) => sum + income.amount, 0);
+  const totalIncome = totalIncomeFromTransactions + recurringIncome;
   const totalExpenses = input.transactions
     .filter((txn) => txn.amount < 0)
     .reduce((sum, txn) => sum + Math.abs(txn.amount), 0);
@@ -85,6 +89,16 @@ export function generateInsights(input: InsightInput): Insight[] {
       title: 'Custom expense categories in use',
       description: `You are tracking ${customExpenseCategories.length} custom expense categories. Continue refining to improve AI recommendations.`,
       severity: 'info'
+    });
+  }
+
+  const uncoveredIncome = input.monthlyIncomes.filter((income) => !income.categoryId);
+  if (uncoveredIncome.length > 0) {
+    insights.push({
+      id: 'insight-income-categorisation',
+      title: 'Categorise income streams',
+      description: `${uncoveredIncome.length} income entries are uncategorised. Tag them to align tax planning and savings goals.`,
+      severity: 'warning'
     });
   }
 

--- a/src/services/wealthAcceleratorEngine.ts
+++ b/src/services/wealthAcceleratorEngine.ts
@@ -1,21 +1,25 @@
-import type { Account, Goal, RecurringExpense, Transaction, WealthAcceleratorMetrics } from '../types';
+import type { Account, Goal, MonthlyIncome, RecurringExpense, Transaction, WealthAcceleratorMetrics } from '../types';
 import { differenceInMonths, parseISO } from 'date-fns';
 
 export function simulateWealthAccelerator(
   accounts: Account[],
   transactions: Transaction[],
   goals: Goal[],
-  recurringExpenses: RecurringExpense[]
+  recurringExpenses: RecurringExpense[],
+  monthlyIncomes: MonthlyIncome[]
 ): WealthAcceleratorMetrics {
   const investableAssets = accounts
     .filter((acct) => acct.type === 'investment' || acct.type === 'bank')
     .reduce((sum, acct) => sum + acct.balance, 0);
   const liabilities = accounts.filter((acct) => acct.type === 'loan').reduce((sum, acct) => sum + acct.balance, 0);
 
-  const monthlySavings = transactions
+  const transactionIncome = transactions
     .filter((txn) => txn.amount > 0)
-    .reduce((sum, txn) => sum + txn.amount, 0) +
-    transactions.filter((txn) => txn.amount < 0).reduce((sum, txn) => sum + txn.amount, 0);
+    .reduce((sum, txn) => sum + txn.amount, 0);
+  const recurringIncome = monthlyIncomes.reduce((sum, income) => sum + income.amount, 0);
+  const totalIncome = transactionIncome + recurringIncome;
+  const totalExpenses = transactions.filter((txn) => txn.amount < 0).reduce((sum, txn) => sum + Math.abs(txn.amount), 0);
+  const monthlySavings = totalIncome - totalExpenses;
 
   const cashFlowHealth = Math.max(0, Math.min(100, (monthlySavings / Math.max(1, liabilities)) * 100));
   const capitalEfficiencyScore = Math.round(

--- a/src/store/FinancialStoreProvider.tsx
+++ b/src/store/FinancialStoreProvider.tsx
@@ -5,6 +5,7 @@ import type {
   FinancialSnapshot,
   Goal,
   Insight,
+  MonthlyIncome,
   PlannedExpenseItem,
   RecurringExpense,
   Transaction
@@ -22,6 +23,7 @@ const defaultState: FinancialStoreState = {
   accounts: [],
   categories: [],
   transactions: [],
+  monthlyIncomes: [],
   plannedExpenses: [],
   recurringExpenses: [],
   goals: [],
@@ -41,6 +43,9 @@ interface FinancialStoreActions {
   addCategory(payload: Omit<Category, 'id'>): Promise<Category>;
   updateCategory(id: string, payload: Partial<Category>): Promise<void>;
   deleteCategory(id: string): Promise<void>;
+  addMonthlyIncome(payload: Omit<MonthlyIncome, 'id'>): Promise<MonthlyIncome>;
+  updateMonthlyIncome(id: string, payload: Partial<MonthlyIncome>): Promise<void>;
+  deleteMonthlyIncome(id: string): Promise<void>;
   addPlannedExpense(payload: Omit<PlannedExpenseItem, 'id' | 'status'> & { status?: PlannedExpenseItem['status'] }): Promise<PlannedExpenseItem>;
   updatePlannedExpense(id: string, payload: Partial<PlannedExpenseItem>): Promise<void>;
   deletePlannedExpense(id: string): Promise<void>;
@@ -65,7 +70,12 @@ export function FinancialStoreProvider({ children }: { children: ReactNode }) {
     (async () => {
       const snapshot = await loadSnapshot();
       if (snapshot) {
-        setState((prev) => ({ ...prev, ...snapshot, isReady: true }));
+        setState((prev) => ({
+          ...prev,
+          ...snapshot,
+          monthlyIncomes: snapshot.monthlyIncomes ?? [],
+          isReady: true
+        }));
       } else {
         await refresh();
       }
@@ -77,6 +87,7 @@ export function FinancialStoreProvider({ children }: { children: ReactNode }) {
     accounts: state.accounts,
     categories: state.categories,
     transactions: state.transactions,
+    monthlyIncomes: state.monthlyIncomes,
     plannedExpenses: state.plannedExpenses,
     recurringExpenses: state.recurringExpenses,
     goals: state.goals,
@@ -100,7 +111,8 @@ export function FinancialStoreProvider({ children }: { children: ReactNode }) {
       manualTransactions: state.transactions.filter(
         (txn) => txn.accountId !== 'acct-hdfc-savings' && txn.accountId !== 'acct-zerodha-invest'
       ),
-      manualCategories: state.categories.filter((cat) => cat.isCustom)
+      manualCategories: state.categories.filter((cat) => cat.isCustom),
+      manualMonthlyIncomes: state.monthlyIncomes.filter((income) => income.id.startsWith('custom-'))
     });
     setState((prev) => ({ ...prev, ...snapshot, isReady: true, isSyncing: false, lastSyncedAt: new Date().toISOString() }));
   };
@@ -128,14 +140,16 @@ export function FinancialStoreProvider({ children }: { children: ReactNode }) {
   const deleteCategory: FinancialStoreActions['deleteCategory'] = async (id) => {
     await persistAndSet((prev) => {
       const remainingCategories = prev.categories.filter((category) => category.id !== id);
+      const deletedCategory = prev.categories.find((category) => category.id === id);
       let fallbackCategory =
-        remainingCategories.find((category) => category.type === 'expense') ?? remainingCategories[0];
+        remainingCategories.find((category) => category.type === (deletedCategory?.type ?? 'expense')) ??
+        remainingCategories[0];
       const categories = [...remainingCategories];
       if (!fallbackCategory) {
         fallbackCategory = {
           id: crypto.randomUUID(),
           name: 'Uncategorised',
-          type: 'expense',
+          type: deletedCategory?.type ?? 'expense',
           isCustom: true
         } satisfies Category;
         categories.push(fallbackCategory);
@@ -161,9 +175,43 @@ export function FinancialStoreProvider({ children }: { children: ReactNode }) {
                 categoryId: fallbackCategory.id
               }
             : item
+        ),
+        monthlyIncomes: prev.monthlyIncomes.map((income) =>
+          income.categoryId === id
+            ? {
+                ...income,
+                categoryId: fallbackCategory.id
+              }
+            : income
         )
       };
     });
+  };
+
+  const addMonthlyIncome: FinancialStoreActions['addMonthlyIncome'] = async (payload) => {
+    const newIncome: MonthlyIncome = {
+      ...payload,
+      id: `custom-${crypto.randomUUID()}`
+    };
+    await persistAndSet((prev) => ({
+      ...prev,
+      monthlyIncomes: [...prev.monthlyIncomes, newIncome]
+    }));
+    return newIncome;
+  };
+
+  const updateMonthlyIncome: FinancialStoreActions['updateMonthlyIncome'] = async (id, payload) => {
+    await persistAndSet((prev) => ({
+      ...prev,
+      monthlyIncomes: prev.monthlyIncomes.map((income) => (income.id === id ? { ...income, ...payload } : income))
+    }));
+  };
+
+  const deleteMonthlyIncome: FinancialStoreActions['deleteMonthlyIncome'] = async (id) => {
+    await persistAndSet((prev) => ({
+      ...prev,
+      monthlyIncomes: prev.monthlyIncomes.filter((income) => income.id !== id)
+    }));
   };
 
   const addPlannedExpense: FinancialStoreActions['addPlannedExpense'] = async (payload) => {
@@ -260,6 +308,7 @@ export function FinancialStoreProvider({ children }: { children: ReactNode }) {
     setState((prev) => ({
       ...prev,
       ...snapshot,
+      monthlyIncomes: snapshot.monthlyIncomes ?? [],
       isReady: true,
       lastSyncedAt: new Date().toISOString()
     }));
@@ -272,6 +321,9 @@ export function FinancialStoreProvider({ children }: { children: ReactNode }) {
       addCategory,
       updateCategory,
       deleteCategory,
+      addMonthlyIncome,
+      updateMonthlyIncome,
+      deleteMonthlyIncome,
       addPlannedExpense,
       updatePlannedExpense,
       deletePlannedExpense,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -63,6 +63,15 @@ export interface RecurringExpense {
   nextDueDate?: string;
 }
 
+export interface MonthlyIncome {
+  id: string;
+  source: string;
+  amount: number;
+  categoryId: string;
+  receivedOn: string;
+  notes?: string;
+}
+
 export interface Goal {
   id: string;
   name: string;
@@ -89,6 +98,7 @@ export interface FinancialSnapshot {
   accounts: Account[];
   categories: Category[];
   transactions: Transaction[];
+  monthlyIncomes: MonthlyIncome[];
   plannedExpenses: PlannedExpenseItem[];
   recurringExpenses: RecurringExpense[];
   goals: Goal[];

--- a/src/views/DashboardView.tsx
+++ b/src/views/DashboardView.tsx
@@ -8,7 +8,7 @@ function formatCurrency(value: number) {
 }
 
 export function DashboardView() {
-  const { accounts, transactions, categories, wealthMetrics } = useFinancialStore();
+  const { accounts, transactions, categories, wealthMetrics, monthlyIncomes } = useFinancialStore();
 
   const netWorth = useMemo(() => {
     const assets = accounts
@@ -21,10 +21,13 @@ export function DashboardView() {
   }, [accounts]);
 
   const { monthlyIncome, monthlyExpenses } = useMemo(() => {
-    const income = transactions.filter((txn) => txn.amount > 0).reduce((sum, txn) => sum + txn.amount, 0);
+    const incomeFromTransactions = transactions
+      .filter((txn) => txn.amount > 0)
+      .reduce((sum, txn) => sum + txn.amount, 0);
+    const recurringIncome = monthlyIncomes.reduce((sum, income) => sum + income.amount, 0);
     const expenses = transactions.filter((txn) => txn.amount < 0).reduce((sum, txn) => sum + Math.abs(txn.amount), 0);
-    return { monthlyIncome: income, monthlyExpenses: expenses };
-  }, [transactions]);
+    return { monthlyIncome: incomeFromTransactions + recurringIncome, monthlyExpenses: expenses };
+  }, [transactions, monthlyIncomes]);
 
   const savingsRate = monthlyIncome > 0 ? ((monthlyIncome - monthlyExpenses) / monthlyIncome) * 100 : 0;
 

--- a/src/views/IncomeManagementView.tsx
+++ b/src/views/IncomeManagementView.tsx
@@ -1,0 +1,499 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { format, formatISO, parseISO } from 'date-fns';
+import { useFinancialStore } from '../store/FinancialStoreProvider';
+import type { Category } from '../types';
+
+const categoryTypes: Category['type'][] = ['income', 'expense', 'asset', 'liability'];
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat('en-IN', { style: 'currency', currency: 'INR', maximumFractionDigits: 0 }).format(value);
+}
+
+export function IncomeManagementView() {
+  const {
+    monthlyIncomes,
+    categories,
+    addMonthlyIncome,
+    updateMonthlyIncome,
+    deleteMonthlyIncome,
+    addCategory,
+    updateCategory,
+    deleteCategory
+  } = useFinancialStore();
+
+  const incomeCategories = useMemo(
+    () => categories.filter((category) => category.type === 'income'),
+    [categories]
+  );
+
+  const [incomeForm, setIncomeForm] = useState({
+    source: '',
+    amount: 0,
+    receivedOn: formatISO(new Date(), { representation: 'date' }),
+    categoryId: incomeCategories[0]?.id ?? '',
+    notes: ''
+  });
+
+  useEffect(() => {
+    if (!incomeForm.categoryId && incomeCategories[0]) {
+      setIncomeForm((prev) => ({ ...prev, categoryId: incomeCategories[0].id }));
+    }
+  }, [incomeCategories, incomeForm.categoryId]);
+
+  const [editingIncomeId, setEditingIncomeId] = useState<string | null>(null);
+  const [editingIncomeState, setEditingIncomeState] = useState({
+    source: '',
+    amount: 0,
+    receivedOn: formatISO(new Date(), { representation: 'date' }),
+    categoryId: '',
+    notes: ''
+  });
+
+  const [categoryForm, setCategoryForm] = useState({ name: '', type: 'income' as Category['type'] });
+  const [editingCategoryId, setEditingCategoryId] = useState<string | null>(null);
+  const [editingCategoryState, setEditingCategoryState] = useState({ name: '', type: 'income' as Category['type'] });
+
+  const totalIncome = useMemo(
+    () => monthlyIncomes.reduce((sum, income) => sum + income.amount, 0),
+    [monthlyIncomes]
+  );
+
+  const groupedCategories = useMemo(() => {
+    return categoryTypes.map((type) => ({
+      type,
+      items: categories.filter((category) => category.type === type)
+    }));
+  }, [categories]);
+
+  const handleIncomeSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!incomeForm.categoryId && incomeCategories[0]) {
+      setIncomeForm((prev) => ({ ...prev, categoryId: incomeCategories[0].id }));
+    }
+    await addMonthlyIncome({
+      source: incomeForm.source,
+      amount: Number(incomeForm.amount),
+      receivedOn: incomeForm.receivedOn,
+      categoryId: incomeForm.categoryId || incomeCategories[0]?.id || '',
+      notes: incomeForm.notes || undefined
+    });
+    setIncomeForm((prev) => ({ ...prev, source: '', amount: 0, notes: '' }));
+  };
+
+  const startEditingIncome = (incomeId: string) => {
+    const income = monthlyIncomes.find((item) => item.id === incomeId);
+    if (!income) return;
+    setEditingIncomeId(incomeId);
+    setEditingIncomeState({
+      source: income.source,
+      amount: income.amount,
+      receivedOn: income.receivedOn.slice(0, 10),
+      categoryId: income.categoryId,
+      notes: income.notes ?? ''
+    });
+  };
+
+  const handleIncomeUpdate = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!editingIncomeId) return;
+    await updateMonthlyIncome(editingIncomeId, {
+      source: editingIncomeState.source,
+      amount: Number(editingIncomeState.amount),
+      receivedOn: editingIncomeState.receivedOn,
+      categoryId: editingIncomeState.categoryId,
+      notes: editingIncomeState.notes || undefined
+    });
+    setEditingIncomeId(null);
+  };
+
+  const handleAddCategory = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!categoryForm.name.trim()) return;
+    const category = await addCategory({
+      name: categoryForm.name,
+      type: categoryForm.type,
+      isCustom: true
+    });
+    if (category.type === 'income') {
+      setIncomeForm((prev) => ({ ...prev, categoryId: category.id }));
+    }
+    setCategoryForm({ name: '', type: 'income' });
+  };
+
+  const startEditingCategory = (categoryId: string) => {
+    const category = categories.find((item) => item.id === categoryId);
+    if (!category) return;
+    setEditingCategoryId(categoryId);
+    setEditingCategoryState({ name: category.name, type: category.type });
+  };
+
+  const handleCategoryUpdate = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!editingCategoryId) return;
+    await updateCategory(editingCategoryId, {
+      name: editingCategoryState.name,
+      type: editingCategoryState.type
+    });
+    setEditingCategoryId(null);
+  };
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h2 className="text-2xl font-semibold">Income & Category Management</h2>
+        <p className="text-sm text-slate-400">
+          Capture monthly income inflows, refine budget categories, and keep every stream audit-ready.
+        </p>
+      </header>
+
+      <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-4 sm:p-6">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h3 className="text-lg font-semibold">Monthly income tracker</h3>
+            <p className="text-xs text-slate-500">Maintain predictable inflows and assign them to strategic goals.</p>
+          </div>
+          <div className="rounded-xl border border-slate-800 bg-slate-950/80 px-4 py-3 text-sm">
+            Total committed income: <span className="font-semibold text-success">{formatCurrency(totalIncome)}</span>
+          </div>
+        </div>
+
+        <form onSubmit={handleIncomeSubmit} className="mt-6 grid gap-4 md:grid-cols-2">
+          <div>
+            <label className="text-xs uppercase text-slate-500">Source</label>
+            <input
+              required
+              className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm"
+              value={incomeForm.source}
+              onChange={(event) => setIncomeForm((prev) => ({ ...prev, source: event.target.value }))}
+            />
+          </div>
+          <div>
+            <label className="text-xs uppercase text-slate-500">Amount (₹)</label>
+            <input
+              type="number"
+              min={0}
+              required
+              className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm"
+              value={incomeForm.amount}
+              onChange={(event) => setIncomeForm((prev) => ({ ...prev, amount: Number(event.target.value) }))}
+            />
+          </div>
+          <div>
+            <label className="text-xs uppercase text-slate-500">Received on</label>
+            <input
+              type="date"
+              required
+              className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm"
+              value={incomeForm.receivedOn}
+              onChange={(event) => setIncomeForm((prev) => ({ ...prev, receivedOn: event.target.value }))}
+            />
+          </div>
+          <div>
+            <label className="text-xs uppercase text-slate-500">Category</label>
+            <select
+              className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm"
+              value={incomeForm.categoryId}
+              onChange={(event) => setIncomeForm((prev) => ({ ...prev, categoryId: event.target.value }))}
+            >
+              <option value="">Select category</option>
+              {incomeCategories.map((category) => (
+                <option key={category.id} value={category.id}>
+                  {category.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="md:col-span-2">
+            <label className="text-xs uppercase text-slate-500">Notes</label>
+            <textarea
+              className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm"
+              rows={2}
+              value={incomeForm.notes}
+              onChange={(event) => setIncomeForm((prev) => ({ ...prev, notes: event.target.value }))}
+            />
+          </div>
+          <button
+            type="submit"
+            className="w-full rounded-lg bg-accent px-4 py-2 text-sm font-semibold text-slate-900 hover:bg-sky-300 md:col-span-2 md:w-auto"
+          >
+            Add income stream
+          </button>
+        </form>
+
+        <div className="mt-8 overflow-x-auto">
+          <table className="min-w-full divide-y divide-slate-800 text-sm">
+            <thead className="bg-slate-900/80 text-xs uppercase text-slate-400">
+              <tr>
+                <th className="px-4 py-3 text-left">Source</th>
+                <th className="px-4 py-3 text-left">Category</th>
+                <th className="px-4 py-3 text-left">Received</th>
+                <th className="px-4 py-3 text-right">Amount</th>
+                <th className="px-4 py-3 text-left">Notes</th>
+                <th className="px-4 py-3 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-800">
+              {monthlyIncomes.map((income) => {
+                const category = categories.find((item) => item.id === income.categoryId)?.name ?? 'Uncategorised';
+                const isEditing = editingIncomeId === income.id;
+                return (
+                  <tr key={income.id} className="hover:bg-slate-800/40">
+                    <td className="px-4 py-3">
+                      {isEditing ? (
+                        <input
+                          className="w-full rounded-lg border border-slate-800 bg-slate-950 px-2 py-1 text-sm"
+                          value={editingIncomeState.source}
+                          onChange={(event) =>
+                            setEditingIncomeState((prev) => ({ ...prev, source: event.target.value }))
+                          }
+                        />
+                      ) : (
+                        income.source
+                      )}
+                    </td>
+                    <td className="px-4 py-3">
+                      {isEditing ? (
+                        <select
+                          className="w-full rounded-lg border border-slate-800 bg-slate-950 px-2 py-1 text-sm"
+                          value={editingIncomeState.categoryId}
+                          onChange={(event) =>
+                            setEditingIncomeState((prev) => ({ ...prev, categoryId: event.target.value }))
+                          }
+                        >
+                          <option value="">Select category</option>
+                          {incomeCategories.map((option) => (
+                            <option key={option.id} value={option.id}>
+                              {option.name}
+                            </option>
+                          ))}
+                        </select>
+                      ) : (
+                        category
+                      )}
+                    </td>
+                    <td className="px-4 py-3">
+                      {isEditing ? (
+                        <input
+                          type="date"
+                          className="w-full rounded-lg border border-slate-800 bg-slate-950 px-2 py-1 text-sm"
+                          value={editingIncomeState.receivedOn}
+                          onChange={(event) =>
+                            setEditingIncomeState((prev) => ({ ...prev, receivedOn: event.target.value }))
+                          }
+                        />
+                      ) : (
+                        format(parseISO(income.receivedOn), 'd MMM yyyy')
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-right text-success">
+                      {isEditing ? (
+                        <input
+                          type="number"
+                          min={0}
+                          className="w-full rounded-lg border border-slate-800 bg-slate-950 px-2 py-1 text-sm"
+                          value={editingIncomeState.amount}
+                          onChange={(event) =>
+                            setEditingIncomeState((prev) => ({ ...prev, amount: Number(event.target.value) }))
+                          }
+                        />
+                      ) : (
+                        formatCurrency(income.amount)
+                      )}
+                    </td>
+                    <td className="px-4 py-3">
+                      {isEditing ? (
+                        <input
+                          className="w-full rounded-lg border border-slate-800 bg-slate-950 px-2 py-1 text-sm"
+                          value={editingIncomeState.notes}
+                          onChange={(event) =>
+                            setEditingIncomeState((prev) => ({ ...prev, notes: event.target.value }))
+                          }
+                        />
+                      ) : (
+                        income.notes ?? '—'
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      {isEditing ? (
+                        <div className="flex justify-end gap-2">
+                          <button
+                            type="button"
+                            className="rounded-lg bg-success/20 px-3 py-1 text-xs font-semibold text-success"
+                            onClick={handleIncomeUpdate}
+                          >
+                            Save
+                          </button>
+                          <button
+                            type="button"
+                            className="rounded-lg bg-slate-800 px-3 py-1 text-xs font-semibold"
+                            onClick={() => setEditingIncomeId(null)}
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      ) : (
+                        <div className="flex justify-end gap-2">
+                          <button
+                            type="button"
+                            className="rounded-lg border border-slate-700 px-3 py-1 text-xs font-semibold"
+                            onClick={() => startEditingIncome(income.id)}
+                          >
+                            Edit
+                          </button>
+                          <button
+                            type="button"
+                            className="rounded-lg bg-danger/20 px-3 py-1 text-xs font-semibold text-danger"
+                            onClick={() => deleteMonthlyIncome(income.id)}
+                          >
+                            Delete
+                          </button>
+                        </div>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+              {monthlyIncomes.length === 0 && (
+                <tr>
+                  <td className="px-4 py-3 text-center text-sm text-slate-500" colSpan={6}>
+                    No income entries yet. Add your first source above.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-4 sm:p-6">
+        <h3 className="text-lg font-semibold">Category governance</h3>
+        <p className="text-xs text-slate-500">
+          Create, rename, or retire categories to keep analytics and budgets consistent across the platform.
+        </p>
+
+        <form onSubmit={handleAddCategory} className="mt-6 grid gap-4 md:grid-cols-[1fr,180px,auto]">
+          <input
+            required
+            placeholder="Category name"
+            className="rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm"
+            value={categoryForm.name}
+            onChange={(event) => setCategoryForm((prev) => ({ ...prev, name: event.target.value }))}
+          />
+          <select
+            className="rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm"
+            value={categoryForm.type}
+            onChange={(event) =>
+              setCategoryForm((prev) => ({ ...prev, type: event.target.value as Category['type'] }))
+            }
+          >
+            {categoryTypes.map((type) => (
+              <option key={type} value={type}>
+                {type.charAt(0).toUpperCase() + type.slice(1)}
+              </option>
+            ))}
+          </select>
+          <button
+            type="submit"
+            className="rounded-lg bg-accent px-4 py-2 text-sm font-semibold text-slate-900 hover:bg-sky-300"
+          >
+            Add category
+          </button>
+        </form>
+
+        <div className="mt-6 grid gap-4 lg:grid-cols-2">
+          {groupedCategories.map(({ type, items }) => (
+            <article key={type} className="rounded-xl border border-slate-800 bg-slate-950/70 p-4">
+              <header className="flex items-center justify-between">
+                <div>
+                  <h4 className="text-sm font-semibold uppercase tracking-wide text-slate-400">
+                    {type.toUpperCase()} CATEGORIES
+                  </h4>
+                  <p className="text-xs text-slate-500">{items.length} tracked</p>
+                </div>
+              </header>
+              <ul className="mt-4 space-y-3 text-sm">
+                {items.map((category) => {
+                  const isEditing = editingCategoryId === category.id;
+                  return (
+                    <li key={category.id} className="rounded-lg border border-slate-800 bg-slate-900/60 p-3">
+                      {isEditing ? (
+                        <form onSubmit={handleCategoryUpdate} className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                          <input
+                            className="flex-1 rounded-lg border border-slate-800 bg-slate-950 px-2 py-1 text-sm"
+                            value={editingCategoryState.name}
+                            onChange={(event) =>
+                              setEditingCategoryState((prev) => ({ ...prev, name: event.target.value }))
+                            }
+                          />
+                          <select
+                            className="rounded-lg border border-slate-800 bg-slate-950 px-2 py-1 text-sm"
+                            value={editingCategoryState.type}
+                            onChange={(event) =>
+                              setEditingCategoryState((prev) => ({
+                                ...prev,
+                                type: event.target.value as Category['type']
+                              }))
+                            }
+                          >
+                            {categoryTypes.map((typeOption) => (
+                              <option key={typeOption} value={typeOption}>
+                                {typeOption.charAt(0).toUpperCase() + typeOption.slice(1)}
+                              </option>
+                            ))}
+                          </select>
+                          <div className="flex gap-2">
+                            <button
+                              type="submit"
+                              className="rounded-lg bg-success/20 px-3 py-1 text-xs font-semibold text-success"
+                            >
+                              Save
+                            </button>
+                            <button
+                              type="button"
+                              className="rounded-lg bg-slate-800 px-3 py-1 text-xs font-semibold"
+                              onClick={() => setEditingCategoryId(null)}
+                            >
+                              Cancel
+                            </button>
+                          </div>
+                        </form>
+                      ) : (
+                        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                          <div>
+                            <p className="font-semibold text-slate-100">{category.name}</p>
+                            <p className="text-xs text-slate-500">
+                              {category.isCustom ? 'Custom' : 'System'} • {category.type}
+                            </p>
+                          </div>
+                          <div className="flex gap-2">
+                            <button
+                              type="button"
+                              className="rounded-lg border border-slate-700 px-3 py-1 text-xs font-semibold"
+                              onClick={() => startEditingCategory(category.id)}
+                            >
+                              Edit
+                            </button>
+                            <button
+                              type="button"
+                              className="rounded-lg bg-danger/20 px-3 py-1 text-xs font-semibold text-danger"
+                              onClick={() => deleteCategory(category.id)}
+                            >
+                              Delete
+                            </button>
+                          </div>
+                        </div>
+                      )}
+                    </li>
+                  );
+                })}
+                {items.length === 0 && (
+                  <li className="text-xs text-slate-500">No categories defined in this group yet.</li>
+                )}
+              </ul>
+            </article>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/views/TrendAnalysisView.tsx
+++ b/src/views/TrendAnalysisView.tsx
@@ -14,14 +14,22 @@ interface MonthlySummary {
 }
 
 export function TrendAnalysisView() {
-  const { transactions, categories } = useFinancialStore();
+  const { transactions, categories, monthlyIncomes } = useFinancialStore();
 
   const monthlySummaries = useMemo(() => {
     const map = new Map<string, MonthlySummary>();
+    const ensureSummary = (date: Date) => {
+      const key = format(date, 'yyyy-MM');
+      const summary = map.get(key);
+      if (summary) return summary;
+      const nextSummary = { month: format(date, 'MMM yyyy'), income: 0, expenses: 0, net: 0 };
+      map.set(key, nextSummary);
+      return nextSummary;
+    };
+
     transactions.forEach((txn) => {
       const date = parseISO(txn.date);
-      const key = format(date, 'yyyy-MM');
-      const summary = map.get(key) ?? { month: format(date, 'MMM yyyy'), income: 0, expenses: 0, net: 0 };
+      const summary = ensureSummary(date);
       if (txn.amount > 0) {
         summary.income += txn.amount;
         summary.net += txn.amount;
@@ -29,12 +37,19 @@ export function TrendAnalysisView() {
         summary.expenses += Math.abs(txn.amount);
         summary.net += txn.amount;
       }
-      map.set(key, summary);
     });
+
+    monthlyIncomes.forEach((income) => {
+      const date = parseISO(income.receivedOn);
+      const summary = ensureSummary(date);
+      summary.income += income.amount;
+      summary.net += income.amount;
+    });
+
     return Array.from(map.entries())
       .sort(([a], [b]) => (a > b ? 1 : -1))
       .map(([, value]) => value);
-  }, [transactions]);
+  }, [transactions, monthlyIncomes]);
 
   const customCategoryTotals = useMemo(() => {
     const totals = new Map<string, number>();


### PR DESCRIPTION
## Summary
- introduce a MonthlyIncome domain model throughout the store, aggregation, insights, and persistence layers so recurring inflows are captured and synced offline
- add an Income & Categories workspace that supports full CRUD for income entries and budget categories and expose it via the main navigation
- fold monthly income data into dashboard metrics and trend analysis so savings and cash-flow visualisations reflect all inflows

## Testing
- npm run test *(fails: vitest missing because dependencies could not be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e104047980832c8ba82609ac197c81