### PR TITLE
chore: switch to scoped lightning fs package

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 registry=https://registry.npmjs.org
 @vitejs:registry=https://registry.npmjs.org
+@isomorphic-git:registry=https://registry.npmjs.org

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "firebase": "^10.12.4",
     "idb": "^7.1.1",
     "isomorphic-git": "^1.25.4",
-    "lightning-fs": "^4.3.0",
+    "@isomorphic-git/lightning-fs": "^4.3.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.23.0",

--- a/src/services/gitVersioningService.ts
+++ b/src/services/gitVersioningService.ts
@@ -1,6 +1,6 @@
 import git from 'isomorphic-git';
 import http from 'isomorphic-git/http/web';
-import LightningFS from 'lightning-fs';
+import LightningFS from '@isomorphic-git/lightning-fs';
 import type { FinancialSnapshot } from '../types';
 import { normaliseSnapshot } from '../utils/snapshotMerge';
 import { encryptData } from './indexedDbService';


### PR DESCRIPTION
## Summary
- replace the deprecated `lightning-fs` dependency with the scoped `@isomorphic-git/lightning-fs` package
- update the Git versioning service to import LightningFS from the scoped package
- configure `.npmrc` to resolve the `@isomorphic-git` scope from the public npm registry

## Testing
- ⚠️ `npm install` *(fails: registry proxy returns 403 for @isomorphic-git/lightning-fs)*
- ⚠️ `npm test` *(fails: vitest missing because install cannot complete)*

------
https://chatgpt.com/codex/tasks/task_e_68e10e981d48832c812061b4f6fe61cb