### PR TITLE
Set up web crypto polyfill

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,9 @@ import App from './App';
 import './styles/index.css';
 import { FinancialStoreProvider } from './store/FinancialStoreProvider';
 import { registerServiceWorker } from './serviceWorkerRegistration';
+import { setupWebCrypto } from './utils/setupWebCrypto';
+
+setupWebCrypto();
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {

--- a/src/utils/setupWebCrypto.ts
+++ b/src/utils/setupWebCrypto.ts
@@ -1,0 +1,14 @@
+export type CryptoLike = {
+  getRandomValues?: (array: ArrayBufferView) => ArrayBufferView;
+};
+
+export function setupWebCrypto(cryptoProvider?: CryptoLike) {
+  const globalObj = globalThis as typeof globalThis & { crypto?: CryptoLike };
+
+  const hasGetRandomValues =
+    typeof globalObj.crypto?.getRandomValues === 'function';
+
+  if (!hasGetRandomValues && cryptoProvider) {
+    globalObj.crypto = cryptoProvider;
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,8 @@
+import { webcrypto } from 'node:crypto';
 import { defineConfig } from 'vite';
+import { setupWebCrypto } from './src/utils/setupWebCrypto';
+
+setupWebCrypto(webcrypto);
 
 export default defineConfig({
   esbuild: {


### PR DESCRIPTION
## Summary
- add a shared helper that sets `globalThis.crypto` when `getRandomValues` is missing
- use the helper from both the Vite config and the browser entry to keep the runtime consistent

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68e112060774832cb65ae0dd5b159fa8