### PR TITLE
Remove Git automation hooks from financial store

### DIFF
--- a/src/components/DataControlPanel.tsx
+++ b/src/components/DataControlPanel.tsx
@@ -1,19 +1,11 @@
-import { useRef, useState, type ChangeEvent, type FormEvent } from 'react';
+import { useRef, type ChangeEvent } from 'react';
 import { useFinancialStore } from '../store/FinancialStoreProvider';
 
 export function DataControlPanel() {
   const {
     exportData,
     exportDataAsCsv,
-    exportGitSnapshot,
-    importData,
-    commitToGit,
-    gitStatus,
-    gitHistory,
-    refreshGitHistory,
-    smartExportRules,
-    addSmartExportRule,
-    deleteSmartExportRule
+    importData
   } = useFinancialStore();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -48,45 +40,11 @@ export function DataControlPanel() {
     URL.revokeObjectURL(url);
   };
 
-  const handleGitCommit = async () => {
-    const defaultMessage = `Manual snapshot ${new Date().toISOString()}`;
-    const message = window.prompt('Commit message for Git snapshot', defaultMessage);
-    if (!message) return;
-    await commitToGit(message, { encrypt: true });
-    await refreshGitHistory();
-  };
-
-  const handleGitArchive = async () => {
-    const blob = await exportGitSnapshot();
-    const url = URL.createObjectURL(blob);
-    const anchor = document.createElement('a');
-    anchor.href = url;
-    anchor.download = `wealth-accelerator-git-${new Date().toISOString()}.json`;
-    anchor.click();
-    URL.revokeObjectURL(url);
-  };
-
-  const lastCommit = gitHistory[0];
-  const [ruleForm, setRuleForm] = useState({ name: '', type: 'weekly' as 'weekly' | 'transaction-count', threshold: 7, gpgKeyFingerprint: '' });
-
-  const handleRuleSubmit = async (event: FormEvent) => {
-    event.preventDefault();
-    if (!ruleForm.name.trim()) return;
-    await addSmartExportRule({
-      name: ruleForm.name,
-      type: ruleForm.type,
-      threshold: Number(ruleForm.threshold),
-      target: 'git',
-      gpgKeyFingerprint: ruleForm.gpgKeyFingerprint || undefined
-    });
-    setRuleForm({ name: '', type: ruleForm.type, threshold: ruleForm.type === 'weekly' ? 7 : 100, gpgKeyFingerprint: '' });
-  };
-
   return (
     <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-4 text-sm">
       <h3 className="text-base font-semibold text-slate-100">Data governance & exports</h3>
       <p className="mt-1 text-xs text-slate-500">
-        Everything stays free: take local backups, publish encrypted Git revisions, and restore data on any device.
+        Everything stays free: take local backups and restore data on any device.
       </p>
       <div className="mt-3 flex flex-wrap gap-2">
         <button
@@ -105,20 +63,6 @@ export function DataControlPanel() {
         </button>
         <button
           type="button"
-          onClick={handleGitCommit}
-          className="rounded-lg border border-accent/60 px-4 py-2 text-xs font-semibold text-accent hover:bg-accent/10"
-        >
-          Commit to Git (encrypted)
-        </button>
-        <button
-          type="button"
-          onClick={handleGitArchive}
-          className="rounded-lg border border-slate-700 px-4 py-2 text-xs font-semibold text-slate-100 hover:bg-slate-800"
-        >
-          Export Git bundle
-        </button>
-        <button
-          type="button"
           onClick={handleImport}
           className="rounded-lg border border-slate-700 px-4 py-2 text-xs font-semibold text-slate-100 hover:bg-slate-800"
         >
@@ -126,88 +70,6 @@ export function DataControlPanel() {
         </button>
         <input ref={fileInputRef} type="file" accept="application/json" hidden onChange={onFileChange} />
       </div>
-      <div className="mt-4 rounded-xl border border-slate-800 bg-slate-950/70 p-4 text-xs text-slate-400">
-        <p className="font-semibold text-slate-200">Git status</p>
-        <p>HEAD: {gitStatus.head ?? 'no commits yet'}</p>
-        <p>Remotes: {gitStatus.remotes.length > 0 ? gitStatus.remotes.map((remote) => remote.remote).join(', ') : 'none'}</p>
-        {lastCommit && (
-          <p className="mt-1 text-slate-300">
-            Last commit {new Date(lastCommit.committedAt).toLocaleString('en-IN')} — {lastCommit.message}
-          </p>
-        )}
-      </div>
-      <section className="mt-4 space-y-3 rounded-xl border border-slate-800 bg-slate-950/70 p-4 text-xs text-slate-400">
-        <header className="flex items-center justify-between">
-          <p className="text-sm font-semibold text-slate-200">Smart export automation</p>
-          <span className="text-[10px] uppercase text-slate-500">Optional encrypted Git rules</span>
-        </header>
-        <form onSubmit={handleRuleSubmit} className="grid gap-2 sm:grid-cols-4">
-          <input
-            required
-            value={ruleForm.name}
-            onChange={(event) => setRuleForm((prev) => ({ ...prev, name: event.target.value }))}
-            className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-xs sm:col-span-2"
-            placeholder="Rule name"
-          />
-          <select
-            value={ruleForm.type}
-            onChange={(event) => {
-              const value = event.target.value as 'weekly' | 'transaction-count';
-              setRuleForm((prev) => ({ ...prev, type: value, threshold: value === 'weekly' ? 7 : 100 }));
-            }}
-            className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-xs"
-          >
-            <option value="weekly">Weekly cadence (days)</option>
-            <option value="transaction-count">Transaction count threshold</option>
-          </select>
-          <input
-            type="number"
-            min={ruleForm.type === 'weekly' ? 1 : 1}
-            value={ruleForm.threshold}
-            onChange={(event) => setRuleForm((prev) => ({ ...prev, threshold: Number(event.target.value) }))}
-            className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-xs"
-            placeholder="Threshold"
-          />
-          <input
-            value={ruleForm.gpgKeyFingerprint}
-            onChange={(event) => setRuleForm((prev) => ({ ...prev, gpgKeyFingerprint: event.target.value }))}
-            className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-xs sm:col-span-3"
-            placeholder="Optional GPG fingerprint for encrypted commits"
-          />
-          <button
-            type="submit"
-            className="rounded-lg bg-accent px-3 py-2 text-xs font-semibold text-slate-900 hover:bg-sky-300"
-          >
-            Add rule
-          </button>
-        </form>
-        <ul className="space-y-2 text-xs">
-          {smartExportRules.map((rule) => (
-            <li
-              key={rule.id}
-              className="flex flex-col gap-1 rounded-lg border border-slate-800 bg-slate-900/80 p-3 sm:flex-row sm:items-center sm:justify-between"
-            >
-              <div>
-                <p className="font-semibold text-slate-200">{rule.name}</p>
-                <p className="text-[11px] text-slate-500">
-                  {rule.type === 'weekly'
-                    ? `Commits every ${rule.threshold} day(s)`
-                    : `Commits after ${rule.threshold} new transactions`}
-                  {rule.lastTriggeredAt && ` • Last run ${new Date(rule.lastTriggeredAt).toLocaleString('en-IN')}`}
-                </p>
-              </div>
-              <button
-                type="button"
-                onClick={() => deleteSmartExportRule(rule.id)}
-                className="self-start rounded-lg border border-slate-700 px-3 py-1 text-[11px] font-semibold text-slate-200 hover:bg-slate-800"
-              >
-                Remove
-              </button>
-            </li>
-          ))}
-          {smartExportRules.length === 0 && <p className="text-[11px] text-slate-500">No automation rules configured yet.</p>}
-        </ul>
-      </section>
     </div>
   );
 }

--- a/src/store/FinancialStoreProvider.tsx
+++ b/src/store/FinancialStoreProvider.tsx
@@ -32,17 +32,6 @@ import {
 import { generateInsights } from '../services/insightsEngine';
 import { simulateWealthAccelerator } from '../services/wealthAcceleratorEngine';
 import { firebaseSyncService } from '../services/firebaseSyncService';
-import {
-  commitSnapshotToGit,
-  configureGitRemote,
-  exportGitRepository,
-  getGitStatus,
-  listGitHistory,
-  pushGitRemote,
-  type GitCommitOptions,
-  type GitCommitSummary,
-  type GitStatusSummary
-} from '../services/gitVersioningService';
 import { mergeSnapshots, normaliseSnapshot } from '../utils/snapshotMerge';
 
 const STORAGE_KEYS = {
@@ -64,12 +53,6 @@ interface SmartExportRulePayload {
   gpgKeyFingerprint?: string;
 }
 
-interface GitAuthConfig {
-  username?: string;
-  password?: string;
-  token?: string;
-}
-
 interface FinancialStoreState extends FinancialSnapshot {
   isReady: boolean;
   isSyncing: boolean;
@@ -79,11 +62,6 @@ interface FinancialStoreState extends FinancialSnapshot {
     state: 'idle' | 'connecting' | 'connected' | 'error';
     error?: string;
   };
-  gitStatus: GitStatusSummary & {
-    lastCommitId?: string;
-    lastCommitAt?: string;
-  };
-  gitHistory: GitCommitSummary[];
 }
 
 interface FinancialStoreActions {
@@ -118,11 +96,6 @@ interface FinancialStoreActions {
   importData(file: Blob): Promise<void>;
   configureFirebase(config: FirebaseSyncConfig): Promise<void>;
   disconnectFirebase(): void;
-  commitToGit(message: string, options?: Omit<GitCommitOptions, 'message'>): Promise<string>;
-  refreshGitHistory(): Promise<void>;
-  configureGit(remote: string, url: string): Promise<void>;
-  pushGit(remote: string, branch?: string, auth?: GitAuthConfig): Promise<void>;
-  exportGitSnapshot(): Promise<Blob>;
 }
 
 type FinancialStoreContextValue = FinancialStoreState & FinancialStoreActions;
@@ -195,9 +168,7 @@ const createDefaultState = (): FinancialStoreState => {
     isReady: false,
     isSyncing: false,
     isInitialised: false,
-    firebaseStatus: { state: 'idle' },
-    gitStatus: { head: null, remotes: [] },
-    gitHistory: []
+    firebaseStatus: { state: 'idle' }
   };
 };
 
@@ -217,7 +188,6 @@ export function FinancialStoreProvider({ children }: { children: ReactNode }) {
         isReady: true,
         isInitialised: Boolean(baseSnapshot.profile)
       }));
-      await refreshGitHistory();
     })();
 
     return () => {
@@ -244,10 +214,8 @@ export function FinancialStoreProvider({ children }: { children: ReactNode }) {
   });
 
   const persistAndSet = async (
-    updater: (snapshot: FinancialSnapshot) => FinancialSnapshot,
-    options: { evaluateAutomation?: boolean } = {}
+    updater: (snapshot: FinancialSnapshot) => FinancialSnapshot
   ) => {
-    const { evaluateAutomation = true } = options;
     let derivedSnapshot: FinancialSnapshot | null = null;
 
     setState((prev) => {
@@ -268,27 +236,10 @@ export function FinancialStoreProvider({ children }: { children: ReactNode }) {
         isInitialised: Boolean(derivedSnapshot?.profile)
       };
     });
-
-    if (evaluateAutomation && derivedSnapshot) {
-      await evaluateSmartExports(derivedSnapshot);
-    }
-  };
-
-  const refreshGitHistory = async () => {
-    const [history, status] = await Promise.all([listGitHistory(20), getGitStatus()]);
-    setState((prev) => ({
-      ...prev,
-      gitHistory: history,
-      gitStatus: {
-        ...status,
-        lastCommitAt: prev.gitStatus.lastCommitAt,
-        lastCommitId: prev.gitStatus.lastCommitId
-      }
-    }));
   };
 
   const logExportEvent = async (
-    event: Omit<ExportEvent, 'id' | 'createdAt' | 'updatedAt'>
+    event: Pick<ExportEvent, 'format' | 'context' | 'trigger'>
   ) => {
     const now = new Date().toISOString();
     await persistAndSet(
@@ -300,90 +251,14 @@ export function FinancialStoreProvider({ children }: { children: ReactNode }) {
             id: crypto.randomUUID(),
             createdAt: now,
             updatedAt: now,
-            ...event
+            trigger: event.trigger,
+            medium: 'file',
+            format: event.format,
+            context: event.context
           }
         ]
-      }),
-      { evaluateAutomation: false }
+      })
     );
-  };
-
-  const evaluateSmartExports = async (snapshot: FinancialSnapshot) => {
-    for (const rule of snapshot.smartExportRules) {
-      if (rule.target !== 'git') continue;
-      if (rule.type === 'weekly') {
-        const lastTrigger = rule.lastTriggeredAt ? new Date(rule.lastTriggeredAt).getTime() : 0;
-        const thresholdMs = rule.threshold * 24 * 60 * 60 * 1000;
-        if (Date.now() - lastTrigger < thresholdMs) continue;
-        await automateGitCommit(rule, snapshot, `Automated weekly export (${rule.threshold} day cadence)`);
-      } else if (rule.type === 'transaction-count') {
-        const lastEvent = [...snapshot.exportHistory]
-          .filter((entry) => entry.ruleId === rule.id && entry.medium === 'git')
-          .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))[0];
-        const baseline = lastEvent?.context?.startsWith('transactions=')
-          ? Number(lastEvent.context.replace('transactions=', ''))
-          : 0;
-        const diff = snapshot.transactions.length - baseline;
-        if (diff < rule.threshold) continue;
-        await automateGitCommit(
-          rule,
-          snapshot,
-          `Automated export after ${rule.threshold} transactions`,
-          `transactions=${snapshot.transactions.length}`
-        );
-      }
-    }
-  };
-
-  const automateGitCommit = async (
-    rule: SmartExportRule,
-    snapshot: FinancialSnapshot,
-    message: string,
-    context?: string
-  ) => {
-    const oid = await commitSnapshotToGit(snapshot, {
-      message,
-      encrypt: Boolean(rule.gpgKeyFingerprint),
-      keyFingerprint: rule.gpgKeyFingerprint
-    });
-    const now = new Date().toISOString();
-    await persistAndSet(
-      (current) => ({
-        ...current,
-        smartExportRules: current.smartExportRules.map((item) =>
-          item.id === rule.id
-            ? {
-                ...item,
-                lastTriggeredAt: now,
-                updatedAt: now
-              }
-            : item
-        ),
-        exportHistory: [
-          ...current.exportHistory,
-          {
-            id: crypto.randomUUID(),
-            trigger: 'automation',
-            medium: 'git',
-            format: 'git',
-            ruleId: rule.id,
-            context,
-            createdAt: now,
-            updatedAt: now
-          }
-        ]
-      }),
-      { evaluateAutomation: false }
-    );
-    setState((prev) => ({
-      ...prev,
-      gitStatus: {
-        ...prev.gitStatus,
-        lastCommitId: oid,
-        lastCommitAt: now
-      }
-    }));
-    await refreshGitHistory();
   };
 
   const refresh = async () => {
@@ -711,30 +586,26 @@ export function FinancialStoreProvider({ children }: { children: ReactNode }) {
     await persistAndSet((snapshot) => ({
       ...snapshot,
       smartExportRules: [...snapshot.smartExportRules, rule]
-    }),
-    { evaluateAutomation: false });
+    }));
     return rule;
   };
 
   const deleteSmartExportRule: FinancialStoreActions['deleteSmartExportRule'] = async (id) => {
-    await persistAndSet(
-      (snapshot) => ({
-        ...snapshot,
-        smartExportRules: snapshot.smartExportRules.filter((rule) => rule.id !== id)
-      }),
-      { evaluateAutomation: false }
-    );
+    await persistAndSet((snapshot) => ({
+      ...snapshot,
+      smartExportRules: snapshot.smartExportRules.filter((rule) => rule.id !== id)
+    }));
   };
 
   const exportData: FinancialStoreActions['exportData'] = async () => {
     const blob = await exportSnapshot();
-    await logExportEvent({ trigger: 'manual', medium: 'file', format: 'json' });
+    await logExportEvent({ trigger: 'manual', format: 'json' });
     return blob;
   };
 
   const exportDataAsCsvAction: FinancialStoreActions['exportDataAsCsv'] = async () => {
     const blob = await exportSnapshotAsCsv();
-    await logExportEvent({ trigger: 'manual', medium: 'file', format: 'csv' });
+    await logExportEvent({ trigger: 'manual', format: 'csv' });
     return blob;
   };
 
@@ -802,38 +673,6 @@ export function FinancialStoreProvider({ children }: { children: ReactNode }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const commitToGit: FinancialStoreActions['commitToGit'] = async (message, options) => {
-    const snapshot = deriveFromSnapshot(toSnapshot(state));
-    const oid = await commitSnapshotToGit(snapshot, { message, ...options });
-    const now = new Date().toISOString();
-    await logExportEvent({ trigger: 'manual', medium: 'git', format: 'git', context: message });
-    setState((prev) => ({
-      ...prev,
-      gitStatus: {
-        ...prev.gitStatus,
-        lastCommitId: oid,
-        lastCommitAt: now
-      }
-    }));
-    await refreshGitHistory();
-    return oid;
-  };
-
-  const configureGitAction: FinancialStoreActions['configureGit'] = async (remote, url) => {
-    await configureGitRemote(remote, url);
-    await refreshGitHistory();
-  };
-
-  const pushGitAction: FinancialStoreActions['pushGit'] = async (remote, branch = 'main', auth) => {
-    await pushGitRemote(remote, branch, auth);
-  };
-
-  const exportGitSnapshot: FinancialStoreActions['exportGitSnapshot'] = async () => {
-    const blob = await exportGitRepository();
-    await logExportEvent({ trigger: 'manual', medium: 'git', format: 'git', context: 'git-export' });
-    return blob;
-  };
-
   const contextValue = useMemo<FinancialStoreContextValue>(
     () => ({
       ...state,
@@ -861,12 +700,7 @@ export function FinancialStoreProvider({ children }: { children: ReactNode }) {
       exportDataAsCsv: exportDataAsCsvAction,
       importData: importDataAction,
       configureFirebase,
-      disconnectFirebase,
-      commitToGit,
-      refreshGitHistory,
-      configureGit: configureGitAction,
-      pushGit: pushGitAction,
-      exportGitSnapshot
+      disconnectFirebase
     }),
     [state]
   );


### PR DESCRIPTION
## Summary
- remove git versioning state and actions from the financial store provider
- ensure export history logging only tracks file-based exports while simplifying state persistence
- update the data control panel to present file backup and restore controls only

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e115f12a74832caf128d3b59c18e03