### PR TITLE
Add ledger setup skip controls and refine savings gauge

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,8 @@ import { InsightsView } from './views/InsightsView';
 import { WealthAcceleratorView } from './views/WealthAcceleratorView';
 import { OfflineSyncStatus } from './components/OfflineSyncStatus';
 import { InitialSetupDialog } from './components/InitialSetupDialog';
+import { QuickExpenseCapture } from './components/QuickExpenseCapture';
+import { useFinancialStore } from './store/FinancialStoreProvider';
 
 const navLinkClass = ({ isActive }: { isActive: boolean }) =>
   `px-4 py-2 rounded-md text-sm font-medium transition-colors duration-200 ${
@@ -20,6 +22,7 @@ const navLinkClass = ({ isActive }: { isActive: boolean }) =>
 export default function App() {
   const [isNavOpen, setIsNavOpen] = useState(false);
   const location = useLocation();
+  const { isInitialised, hasDismissedInitialSetup, requestInitialSetup } = useFinancialStore();
 
   useEffect(() => {
     setIsNavOpen(false);
@@ -47,8 +50,17 @@ export default function App() {
               Menu
             </button>
           </div>
-          <div className="md:min-w-[260px]">
+          <div className="flex flex-col items-stretch gap-2 md:min-w-[260px]">
             <OfflineSyncStatus />
+            {!isInitialised && hasDismissedInitialSetup ? (
+              <button
+                type="button"
+                onClick={requestInitialSetup}
+                className="rounded-lg border border-accent/50 px-3 py-2 text-xs font-semibold text-accent transition hover:bg-accent/10"
+              >
+                Resume ledger setup
+              </button>
+            ) : null}
           </div>
         </div>
       </header>
@@ -101,6 +113,7 @@ export default function App() {
           </Routes>
         </main>
       </div>
+      <QuickExpenseCapture />
       <InitialSetupDialog />
     </div>
   );

--- a/src/components/InitialSetupDialog.tsx
+++ b/src/components/InitialSetupDialog.tsx
@@ -7,21 +7,22 @@ const accountTypes: Account['type'][] = ['bank', 'cash', 'investment', 'loan', '
 interface AccountDraft {
   name: string;
   type: Account['type'];
-  balance: number;
+  balance: string;
   notes?: string;
 }
 
 export function InitialSetupDialog() {
-  const { isReady, isInitialised, completeInitialSetup } = useFinancialStore();
+  const { isReady, isInitialised, hasDismissedInitialSetup, completeInitialSetup, dismissInitialSetup } =
+    useFinancialStore();
   const [currency, setCurrency] = useState<Currency>('INR');
   const [financialStartDate, setFinancialStartDate] = useState<string>(new Date().toISOString().slice(0, 10));
   const [openingBalanceNote, setOpeningBalanceNote] = useState('');
   const [accounts, setAccounts] = useState<AccountDraft[]>([
-    { name: '', type: 'bank', balance: 0 },
-    { name: '', type: 'cash', balance: 0 }
+    { name: '', type: 'bank', balance: '' },
+    { name: '', type: 'cash', balance: '' }
   ]);
 
-  if (!isReady || isInitialised) {
+  if (!isReady || isInitialised || hasDismissedInitialSetup) {
     return null;
   }
 
@@ -30,7 +31,7 @@ export function InitialSetupDialog() {
   };
 
   const addAccountRow = () => {
-    setAccounts((prev) => [...prev, { name: '', type: 'bank', balance: 0 }]);
+    setAccounts((prev) => [...prev, { name: '', type: 'bank', balance: '' }]);
   };
 
   const handleSubmit = async (event: FormEvent) => {
@@ -40,7 +41,7 @@ export function InitialSetupDialog() {
       .map((account) => ({
         name: account.name,
         type: account.type,
-        balance: Number(account.balance) || 0,
+        balance: Number.parseFloat(account.balance || '0') || 0,
         currency,
         notes: account.notes
       }));
@@ -148,8 +149,9 @@ export function InitialSetupDialog() {
                     type="number"
                     min={0}
                     value={account.balance}
-                    onChange={(event) => updateAccount(index, { balance: Number(event.target.value) })}
+                    onChange={(event) => updateAccount(index, { balance: event.target.value })}
                     className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2"
+                    placeholder="0"
                   />
                 </div>
                 <div className="sm:col-span-4">
@@ -166,7 +168,14 @@ export function InitialSetupDialog() {
           </div>
         </section>
 
-        <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <button
+            type="button"
+            onClick={dismissInitialSetup}
+            className="text-xs font-semibold uppercase tracking-wide text-slate-500 transition hover:text-slate-300"
+          >
+            Skip for now
+          </button>
           <button
             type="submit"
             className="rounded-lg bg-accent px-4 py-2 text-sm font-semibold text-slate-900 hover:bg-sky-300"

--- a/src/components/QuickExpenseCapture.tsx
+++ b/src/components/QuickExpenseCapture.tsx
@@ -1,0 +1,340 @@
+import { useMemo, useState } from 'react';
+import { useFinancialStore } from '../store/FinancialStoreProvider';
+
+interface FormState {
+  description: string;
+  amount: string;
+  accountId: string;
+  categoryId: string;
+  subcategoryId: string;
+  date: string;
+  notes: string;
+}
+
+const todayInputValue = () => {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = `${now.getMonth() + 1}`.padStart(2, '0');
+  const day = `${now.getDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+export function QuickExpenseCapture() {
+  const { accounts, categories, profile, addManualTransaction } = useFinancialStore();
+  const [isOpen, setIsOpen] = useState(false);
+  const [form, setForm] = useState<FormState>({
+    description: '',
+    amount: '',
+    accountId: '',
+    categoryId: '',
+    subcategoryId: '',
+    date: todayInputValue(),
+    notes: ''
+  });
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showSaved, setShowSaved] = useState(false);
+
+  const expenseCategories = useMemo(
+    () => categories.filter((category) => category.type === 'expense'),
+    [categories]
+  );
+
+  const parentCategories = useMemo(
+    () => expenseCategories.filter((category) => !category.parentId),
+    [expenseCategories]
+  );
+
+  const childCategoriesByParent = useMemo(() => {
+    return expenseCategories.reduce<Record<string, typeof expenseCategories>>((acc, category) => {
+      if (!category.parentId) return acc;
+      if (!acc[category.parentId]) {
+        acc[category.parentId] = [];
+      }
+      acc[category.parentId].push(category);
+      return acc;
+    }, {});
+  }, [expenseCategories]);
+
+  const resetForm = () => {
+    setForm({
+      description: '',
+      amount: '',
+      accountId: '',
+      categoryId: '',
+      subcategoryId: '',
+      date: todayInputValue(),
+      notes: ''
+    });
+    setError(null);
+  };
+
+  const selectedAccountCurrency = useMemo(() => {
+    const selectedAccount = accounts.find((account) => account.id === form.accountId);
+    return selectedAccount?.currency ?? profile?.currency ?? 'INR';
+  }, [accounts, form.accountId, profile?.currency]);
+
+  const activeSubcategories = form.categoryId ? childCategoriesByParent[form.categoryId] ?? [] : [];
+
+  const handleSubmit: React.FormEventHandler<HTMLFormElement> = async (event) => {
+    event.preventDefault();
+    setError(null);
+
+    if (!form.description.trim()) {
+      setError('Please enter what you spent on.');
+      return;
+    }
+
+    const amountValue = Number.parseFloat(form.amount);
+    if (!Number.isFinite(amountValue) || amountValue <= 0) {
+      setError('Enter a valid amount greater than zero.');
+      return;
+    }
+
+    if (!form.accountId) {
+      setError('Choose the account that funded this purchase.');
+      return;
+    }
+
+    if (!form.categoryId && !form.subcategoryId) {
+      setError('Pick a category so the expense can be tracked.');
+      return;
+    }
+
+    const expenseCategoryId = form.subcategoryId || form.categoryId;
+
+    const isoDate = new Date(`${form.date}T00:00:00`).toISOString();
+
+    setIsSaving(true);
+    try {
+      await addManualTransaction({
+        accountId: form.accountId,
+        amount: -Math.abs(amountValue),
+        currency: selectedAccountCurrency,
+        date: isoDate,
+        description: form.description.trim(),
+        categoryId: expenseCategoryId,
+        notes: form.notes.trim() ? form.notes.trim() : undefined
+      });
+      setShowSaved(true);
+      resetForm();
+      setIsOpen(false);
+      window.setTimeout(() => setShowSaved(false), 2800);
+    } catch (saveError) {
+      setError(saveError instanceof Error ? saveError.message : 'Something went wrong while saving.');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const disabled = accounts.length === 0 || parentCategories.length === 0;
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => {
+          if (disabled) {
+            setShowSaved(false);
+            setError('Add an account and expense categories first to start tracking spends.');
+            setIsOpen(true);
+            return;
+          }
+          setError(null);
+          setIsOpen(true);
+        }}
+        className="fixed bottom-6 right-6 z-40 flex items-center gap-2 rounded-full bg-accent px-5 py-3 text-sm font-semibold text-slate-900 shadow-lg transition hover:shadow-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+      >
+        <span className="text-lg leading-none">＋</span>
+        Log spend
+      </button>
+
+      {isOpen ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 p-4">
+          <div className="w-full max-w-xl rounded-2xl border border-slate-700 bg-slate-900/95 p-6 shadow-2xl">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h2 className="text-xl font-semibold text-accent">Log a new spend</h2>
+                <p className="mt-1 text-sm text-slate-400">
+                  Capture purchases instantly so your dashboards stay current.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => {
+                  setIsOpen(false);
+                  setError(null);
+                }}
+                className="rounded-full border border-transparent p-1 text-slate-400 transition hover:text-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                aria-label="Close"
+              >
+                ✕
+              </button>
+            </div>
+
+            {disabled ? (
+              <div className="mt-6 rounded-lg border border-dashed border-slate-700 bg-slate-900/70 p-4 text-sm text-slate-400">
+                You need at least one account and an expense category before recording spends. Add them from the Income &amp;
+                Categories view first.
+              </div>
+            ) : (
+              <form onSubmit={handleSubmit} className="mt-6 space-y-5">
+                <div>
+                  <label className="block text-sm font-medium text-slate-200" htmlFor="description">
+                    What did you spend on?
+                  </label>
+                  <input
+                    id="description"
+                    type="text"
+                    className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 shadow-inner focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/40"
+                    placeholder="e.g. iPhone 15 Pro"
+                    value={form.description}
+                    onChange={(event) => setForm((prev) => ({ ...prev, description: event.target.value }))}
+                    required
+                  />
+                </div>
+
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div>
+                    <label className="block text-sm font-medium text-slate-200" htmlFor="amount">
+                      Amount ({selectedAccountCurrency})
+                    </label>
+                    <input
+                      id="amount"
+                      type="number"
+                      min="0"
+                      step="0.01"
+                      inputMode="decimal"
+                      className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 shadow-inner focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/40"
+                      placeholder="0.00"
+                      value={form.amount}
+                      onChange={(event) => setForm((prev) => ({ ...prev, amount: event.target.value }))}
+                      required
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-slate-200" htmlFor="date">
+                      Date
+                    </label>
+                    <input
+                      id="date"
+                      type="date"
+                      className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 shadow-inner focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/40"
+                      value={form.date}
+                      max={todayInputValue()}
+                      onChange={(event) => setForm((prev) => ({ ...prev, date: event.target.value }))}
+                      required
+                    />
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-slate-200" htmlFor="account">
+                    Paid from account
+                  </label>
+                  <select
+                    id="account"
+                    className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/40"
+                    value={form.accountId}
+                    onChange={(event) => setForm((prev) => ({ ...prev, accountId: event.target.value }))}
+                    required
+                  >
+                    <option value="">Select an account</option>
+                    {accounts.map((account) => (
+                      <option key={account.id} value={account.id}>
+                        {account.name} · {account.currency} · Balance {account.balance.toLocaleString()}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div>
+                    <label className="block text-sm font-medium text-slate-200" htmlFor="category">
+                      Category
+                    </label>
+                    <select
+                      id="category"
+                      className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/40"
+                      value={form.categoryId}
+                      onChange={(event) => setForm((prev) => ({ ...prev, categoryId: event.target.value, subcategoryId: '' }))}
+                      required
+                    >
+                      <option value="">Select category</option>
+                      {parentCategories.map((category) => (
+                        <option key={category.id} value={category.id}>
+                          {category.name}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-slate-200" htmlFor="subcategory">
+                      Sub-category (optional)
+                    </label>
+                    <select
+                      id="subcategory"
+                      className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/40 disabled:cursor-not-allowed disabled:opacity-50"
+                      value={form.subcategoryId}
+                      onChange={(event) => setForm((prev) => ({ ...prev, subcategoryId: event.target.value }))}
+                      disabled={activeSubcategories.length === 0}
+                    >
+                      <option value="">No sub-category</option>
+                      {activeSubcategories.map((subcategory) => (
+                        <option key={subcategory.id} value={subcategory.id}>
+                          {subcategory.name}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-slate-200" htmlFor="notes">
+                    Notes (optional)
+                  </label>
+                  <textarea
+                    id="notes"
+                    rows={2}
+                    className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 shadow-inner focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/40"
+                    placeholder="Add context such as warranty or payment terms"
+                    value={form.notes}
+                    onChange={(event) => setForm((prev) => ({ ...prev, notes: event.target.value }))}
+                  />
+                </div>
+
+                {error ? <p className="text-sm text-rose-400">{error}</p> : null}
+
+                <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setIsOpen(false);
+                      setError(null);
+                    }}
+                    className="rounded-lg border border-slate-700 px-4 py-2 text-sm font-medium text-slate-300 transition hover:border-slate-500 hover:text-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="submit"
+                    disabled={isSaving}
+                    className="inline-flex items-center justify-center rounded-lg bg-accent px-4 py-2 text-sm font-semibold text-slate-900 shadow transition hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent disabled:cursor-not-allowed disabled:opacity-70"
+                  >
+                    {isSaving ? 'Saving…' : 'Save expense'}
+                  </button>
+                </div>
+              </form>
+            )}
+          </div>
+        </div>
+      ) : null}
+
+      {showSaved ? (
+        <div className="fixed bottom-6 right-6 z-30 rounded-lg border border-emerald-500/60 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-300 shadow-lg backdrop-blur">
+          Spend saved. Dashboards will refresh automatically.
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/src/services/insightsEngine.ts
+++ b/src/services/insightsEngine.ts
@@ -7,7 +7,8 @@ import type {
   PlannedExpenseItem,
   RecurringExpense,
   Transaction,
-  MonthlyIncome
+  MonthlyIncome,
+  Profile
 } from '../types';
 
 interface InsightInput {
@@ -18,11 +19,23 @@ interface InsightInput {
   goals: Goal[];
   categories: Category[];
   monthlyIncomes: MonthlyIncome[];
+  currency?: Profile['currency'];
 }
 
 export function generateInsights(input: InsightInput): Insight[] {
   const insights: Insight[] = [];
   const now = new Date().toISOString();
+  const currencyFormatter = new Intl.NumberFormat('en-IN', {
+    style: 'currency',
+    currency: input.currency ?? 'INR',
+    maximumFractionDigits: 0
+  });
+
+  const percentageFormatter = new Intl.NumberFormat('en-IN', {
+    style: 'percent',
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1
+  });
 
   const totalIncomeFromTransactions = input.transactions
     .filter((txn) => txn.amount > 0)
@@ -34,14 +47,39 @@ export function generateInsights(input: InsightInput): Insight[] {
     .reduce((sum, txn) => sum + Math.abs(txn.amount), 0);
 
   if (totalIncome > 0) {
-    const savingsRate = ((totalIncome - totalExpenses) / totalIncome) * 100;
+    const savingsRate = (totalIncome - totalExpenses) / totalIncome;
+    const formattedSavingsRate = percentageFormatter.format(savingsRate);
+    const targetSavingsRate = 0.4;
+    const desiredMonthlySavings = targetSavingsRate * totalIncome;
+    const currentMonthlySavings = totalIncome - totalExpenses;
+    const additionalSavingsNeeded = Math.max(desiredMonthlySavings - currentMonthlySavings, 0);
     insights.push({
       id: 'insight-savings-rate',
       title: 'Savings Rate Check',
-      description: `Your savings rate is ${savingsRate.toFixed(1)}%. Consider targeting 40%+ to accelerate investments.`,
-      severity: savingsRate < 30 ? 'warning' : 'info',
+      description: `Your savings rate is ${formattedSavingsRate}. Consider targeting 40%+ to accelerate investments.`,
+      severity: savingsRate < 0.3 ? 'warning' : 'info',
       createdAt: now,
-      updatedAt: now
+      updatedAt: now,
+      metricSummary: {
+        label: 'Current monthly savings',
+        value: currencyFormatter.format(currentMonthlySavings),
+        helperText: `Based on ${currencyFormatter.format(totalExpenses)} in monthly expenses.`
+      },
+      recommendations: [
+        'Automate a monthly transfer into your investment account for the target savings amount.',
+        'Audit the top three discretionary categories to find quick 5-10% reductions.'
+      ],
+      projection:
+        additionalSavingsNeeded > 0
+          ? {
+              title: 'Path to 40% savings rate',
+              description: 'Reducing discretionary spends unlocks additional investable surplus each month.',
+              currentValue: currentMonthlySavings,
+              projectedValue: desiredMonthlySavings,
+              timeframe: 'Next 30 days',
+              unit: 'currency'
+            }
+          : undefined
     });
   }
 
@@ -56,10 +94,14 @@ export function generateInsights(input: InsightInput): Insight[] {
     insights.push({
       id: 'insight-next-recurring',
       title: 'Upcoming recurring payment',
-      description: `${nextRecurring.name} is due soon at ₹${nextRecurring.amount.toLocaleString('en-IN')}. Ensure the budget is allocated.`,
+      description: `${nextRecurring.name} is due soon at ${currencyFormatter.format(nextRecurring.amount)}. Ensure the budget is allocated.`,
       severity: 'info',
       createdAt: now,
-      updatedAt: now
+      updatedAt: now,
+      recommendations: [
+        'Enable autopay or calendar reminders to avoid last-minute cash crunches.',
+        'Park the amount in a high-yield savings bucket until the debit date.'
+      ]
     });
   }
 
@@ -69,10 +111,14 @@ export function generateInsights(input: InsightInput): Insight[] {
     insights.push({
       id: 'insight-planned-spend',
       title: 'Review planned variable expenses',
-      description: `You have ₹${totalPlanned.toLocaleString('en-IN')} of planned spends. Consider staggering purchases to reduce cash flow stress.`,
+      description: `You have ${currencyFormatter.format(totalPlanned)} of planned spends. Consider staggering purchases to reduce cash flow stress.`,
       severity: 'warning',
       createdAt: now,
-      updatedAt: now
+      updatedAt: now,
+      recommendations: [
+        'Tag each planned item as essential or deferrable to make trade-offs explicit.',
+        'Convert large purchases into short-term sinking funds before committing.'
+      ]
     });
   }
 
@@ -87,7 +133,12 @@ export function generateInsights(input: InsightInput): Insight[] {
       description: 'Loan balances are more than 50% of liquid assets. Consider accelerating repayments.',
       severity: 'critical',
       createdAt: now,
-      updatedAt: now
+      updatedAt: now,
+      recommendations: [
+        'Channel every bonus or windfall toward the smallest balance first (debt snowball).',
+        'Assess refinancing offers to cut your blended interest rate by 1-2%.',
+        'Pause new discretionary EMI commitments until leverage drops below 35%.'
+      ]
     });
   }
 
@@ -99,7 +150,11 @@ export function generateInsights(input: InsightInput): Insight[] {
       description: `You are tracking ${customExpenseCategories.length} custom expense categories. Continue refining to improve AI recommendations.`,
       severity: 'info',
       createdAt: now,
-      updatedAt: now
+      updatedAt: now,
+      recommendations: [
+        'Add budgeting targets for each custom bucket to unlock hyper-personal nudges.',
+        'Map custom categories to long-term goals so progress can be measured monthly.'
+      ]
     });
   }
 
@@ -111,7 +166,11 @@ export function generateInsights(input: InsightInput): Insight[] {
       description: `${uncoveredIncome.length} income entries are uncategorised. Tag them to align tax planning and savings goals.`,
       severity: 'warning',
       createdAt: now,
-      updatedAt: now
+      updatedAt: now,
+      recommendations: [
+        'Link each inflow to a goal (Emergency fund, SIP, debt payoff) to auto-allocate surplus.',
+        'Set a recurring rule to auto-tag salary, reimbursements, and side hustles.'
+      ]
     });
   }
 

--- a/src/store/FinancialStoreProvider.tsx
+++ b/src/store/FinancialStoreProvider.tsx
@@ -57,6 +57,7 @@ interface FinancialStoreState extends FinancialSnapshot {
   isReady: boolean;
   isSyncing: boolean;
   isInitialised: boolean;
+  hasDismissedInitialSetup: boolean;
   lastSyncedAt?: string;
   firebaseStatus: {
     state: 'idle' | 'connecting' | 'connected' | 'error';
@@ -67,6 +68,8 @@ interface FinancialStoreState extends FinancialSnapshot {
 interface FinancialStoreActions {
   refresh(): Promise<void>;
   completeInitialSetup(payload: InitialSetupPayload): Promise<void>;
+  dismissInitialSetup(): void;
+  requestInitialSetup(): void;
   updateProfile(payload: Partial<Omit<Profile, 'createdAt' | 'updatedAt'>>): Promise<void>;
   addCategory(payload: Omit<Category, 'id' | 'createdAt' | 'updatedAt' | 'isCustom'> & { isCustom?: boolean }): Promise<Category>;
   updateCategory(id: string, payload: Partial<Category>): Promise<void>;
@@ -101,6 +104,26 @@ interface FinancialStoreActions {
 type FinancialStoreContextValue = FinancialStoreState & FinancialStoreActions;
 
 const FinancialStoreContext = createContext<FinancialStoreContextValue | undefined>(undefined);
+
+const INITIAL_SETUP_DISMISS_KEY = 'wealth-accelerator-initial-setup-dismissed';
+
+const readInitialSetupDismissed = () => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  return window.localStorage.getItem(INITIAL_SETUP_DISMISS_KEY) === 'true';
+};
+
+const persistInitialSetupDismissed = (value: boolean) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  if (value) {
+    window.localStorage.setItem(INITIAL_SETUP_DISMISS_KEY, 'true');
+  } else {
+    window.localStorage.removeItem(INITIAL_SETUP_DISMISS_KEY);
+  }
+};
 
 const createDefaultSnapshot = (): FinancialSnapshot => {
   const now = new Date().toISOString();
@@ -147,7 +170,8 @@ const deriveFromSnapshot = (snapshot: FinancialSnapshot): FinancialSnapshot => {
     plannedExpenses: snapshot.plannedExpenses,
     goals: snapshot.goals,
     categories: snapshot.categories,
-    monthlyIncomes: snapshot.monthlyIncomes
+    monthlyIncomes: snapshot.monthlyIncomes,
+    currency: snapshot.profile?.currency
   }).map((insight) => ({
     ...insight,
     createdAt: insight.createdAt ?? now,
@@ -168,12 +192,16 @@ const createDefaultState = (): FinancialStoreState => {
     isReady: false,
     isSyncing: false,
     isInitialised: false,
+    hasDismissedInitialSetup: false,
     firebaseStatus: { state: 'idle' }
   };
 };
 
 export function FinancialStoreProvider({ children }: { children: ReactNode }) {
-  const [state, setState] = useState<FinancialStoreState>(createDefaultState);
+  const [state, setState] = useState<FinancialStoreState>(() => ({
+    ...createDefaultState(),
+    hasDismissedInitialSetup: readInitialSetupDismissed()
+  }));
   const firebaseConfigRef = useRef<FirebaseSyncConfig | null>(null);
 
   useEffect(() => {
@@ -182,12 +210,19 @@ export function FinancialStoreProvider({ children }: { children: ReactNode }) {
       const stored = await loadSnapshot();
       if (!mounted) return;
       const baseSnapshot = stored ? deriveFromSnapshot(stored) : createDefaultSnapshot();
-      setState((prev) => ({
-        ...prev,
-        ...baseSnapshot,
-        isReady: true,
-        isInitialised: Boolean(baseSnapshot.profile)
-      }));
+      setState((prev) => {
+        const initialised = Boolean(baseSnapshot.profile);
+        if (initialised) {
+          persistInitialSetupDismissed(false);
+        }
+        return {
+          ...prev,
+          ...baseSnapshot,
+          isReady: true,
+          isInitialised: initialised,
+          hasDismissedInitialSetup: initialised ? false : prev.hasDismissedInitialSetup
+        };
+      });
     })();
 
     return () => {
@@ -227,11 +262,16 @@ export function FinancialStoreProvider({ children }: { children: ReactNode }) {
       };
       derivedSnapshot = deriveFromSnapshot(withMeta);
       void persistSnapshot(derivedSnapshot);
+      const initialised = Boolean(derivedSnapshot?.profile);
+      if (initialised) {
+        persistInitialSetupDismissed(false);
+      }
       return {
         ...prev,
         ...derivedSnapshot,
         isReady: true,
-        isInitialised: Boolean(derivedSnapshot?.profile)
+        isInitialised: initialised,
+        hasDismissedInitialSetup: initialised ? false : prev.hasDismissedInitialSetup
       };
     });
 
@@ -276,6 +316,7 @@ export function FinancialStoreProvider({ children }: { children: ReactNode }) {
           ...merged,
           isSyncing: false,
           isInitialised: Boolean(merged.profile),
+          hasDismissedInitialSetup: Boolean(merged.profile) ? false : prev.hasDismissedInitialSetup,
           lastSyncedAt: new Date().toISOString()
         }));
         return;
@@ -285,6 +326,9 @@ export function FinancialStoreProvider({ children }: { children: ReactNode }) {
       ...prev,
       ...currentSnapshot,
       isSyncing: false,
+      hasDismissedInitialSetup: Boolean(currentSnapshot.profile)
+        ? false
+        : prev.hasDismissedInitialSetup,
       lastSyncedAt: new Date().toISOString()
     }));
   };
@@ -315,6 +359,22 @@ export function FinancialStoreProvider({ children }: { children: ReactNode }) {
         accounts
       };
     });
+  };
+
+  const dismissInitialSetup: FinancialStoreActions['dismissInitialSetup'] = () => {
+    persistInitialSetupDismissed(true);
+    setState((prev) => ({
+      ...prev,
+      hasDismissedInitialSetup: true
+    }));
+  };
+
+  const requestInitialSetup: FinancialStoreActions['requestInitialSetup'] = () => {
+    persistInitialSetupDismissed(false);
+    setState((prev) => ({
+      ...prev,
+      hasDismissedInitialSetup: false
+    }));
   };
 
   const updateProfile: FinancialStoreActions['updateProfile'] = async (payload) => {
@@ -618,7 +678,8 @@ export function FinancialStoreProvider({ children }: { children: ReactNode }) {
       ...prev,
       ...derived,
       isReady: true,
-      isInitialised: Boolean(derived.profile)
+      isInitialised: Boolean(derived.profile),
+      hasDismissedInitialSetup: Boolean(derived.profile) ? false : prev.hasDismissedInitialSetup
     }));
   };
 
@@ -643,6 +704,7 @@ export function FinancialStoreProvider({ children }: { children: ReactNode }) {
             ...prev,
             ...merged,
             isInitialised: Boolean(merged.profile),
+            hasDismissedInitialSetup: Boolean(merged.profile) ? false : prev.hasDismissedInitialSetup,
             lastSyncedAt: new Date().toISOString(),
             firebaseStatus: { state: 'connected' }
           };
@@ -679,6 +741,8 @@ export function FinancialStoreProvider({ children }: { children: ReactNode }) {
       ...state,
       refresh,
       completeInitialSetup,
+      dismissInitialSetup,
+      requestInitialSetup,
       updateProfile,
       addCategory,
       updateCategory,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -90,6 +90,20 @@ export interface Insight extends Timestamped {
   title: string;
   description: string;
   severity: 'info' | 'warning' | 'critical';
+  metricSummary?: {
+    label: string;
+    value: string;
+    helperText?: string;
+  };
+  recommendations?: string[];
+  projection?: {
+    title: string;
+    description: string;
+    currentValue: number;
+    projectedValue: number;
+    timeframe: string;
+    unit: 'currency' | 'percentage';
+  };
 }
 
 export interface WealthAcceleratorMetrics {

--- a/src/views/DashboardView.tsx
+++ b/src/views/DashboardView.tsx
@@ -144,7 +144,7 @@ function SavingsGauge({ savingsRate, income, expenses }: { savingsRate: number; 
               strokeLinecap="round"
               strokeWidth="3"
             />
-            <text x="18" y="20.35" className="fill-slate-100 text-lg" textAnchor="middle">
+            <text x="18" y="20.35" className="fill-slate-100 text-base font-semibold" textAnchor="middle">
               {savingsRate.toFixed(1)}%
             </text>
           </svg>

--- a/src/views/InsightsView.tsx
+++ b/src/views/InsightsView.tsx
@@ -1,7 +1,183 @@
+import { useMemo, useState } from 'react';
+import { differenceInCalendarDays, format, isValid, parseISO } from 'date-fns';
 import { useFinancialStore } from '../store/FinancialStoreProvider';
 
 export function InsightsView() {
-  const { insights } = useFinancialStore();
+  const { insights, transactions, categories, profile, recurringExpenses, plannedExpenses } = useFinancialStore();
+  const [ruleReduction, setRuleReduction] = useState(15);
+
+  const currencyFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat('en-IN', {
+        style: 'currency',
+        currency: profile?.currency ?? 'INR',
+        maximumFractionDigits: 0
+      }),
+    [profile?.currency]
+  );
+
+  const percentageFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat('en-IN', {
+        style: 'percent',
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0
+      }),
+    []
+  );
+
+  const spendingAnalysis = useMemo(() => {
+    const expenseTransactions = transactions.filter((txn) => txn.amount < 0);
+
+    if (expenseTransactions.length === 0) {
+      return {
+        monthlyAverage: 0,
+        monthsTracked: 0,
+        topCategories: [] as Array<{ id: string; name: string; monthlyAverage: number; share: number }>
+      };
+    }
+
+    const totalsByMonth = new Map<string, number>();
+    expenseTransactions.forEach((txn) => {
+      const date = new Date(txn.date);
+      if (Number.isNaN(date.getTime())) {
+        return;
+      }
+      const key = `${date.getFullYear()}-${date.getMonth()}`;
+      totalsByMonth.set(key, (totalsByMonth.get(key) ?? 0) + Math.abs(txn.amount));
+    });
+
+    const totalSpend = Array.from(totalsByMonth.values()).reduce((sum, value) => sum + value, 0);
+    const monthsTracked = totalsByMonth.size || 1;
+    const monthlyAverage = totalSpend / monthsTracked;
+
+    const categoryTotals = new Map<string, number>();
+    expenseTransactions.forEach((txn) => {
+      const key = txn.categoryId ?? 'uncategorised';
+      categoryTotals.set(key, (categoryTotals.get(key) ?? 0) + Math.abs(txn.amount));
+    });
+
+    const topCategories = Array.from(categoryTotals.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 3)
+      .map(([categoryId, total]) => {
+        const categoryName = categories.find((cat) => cat.id === categoryId)?.name ?? 'Uncategorised';
+        const categoryMonthlyAverage = total / monthsTracked;
+        const share = monthlyAverage > 0 ? categoryMonthlyAverage / monthlyAverage : 0;
+        return {
+          id: categoryId,
+          name: categoryName,
+          monthlyAverage: categoryMonthlyAverage,
+          share
+        };
+      });
+
+    return { monthlyAverage, monthsTracked, topCategories };
+  }, [transactions, categories]);
+
+  const projectedMonthlySavings = useMemo(
+    () => spendingAnalysis.monthlyAverage * (ruleReduction / 100),
+    [spendingAnalysis.monthlyAverage, ruleReduction]
+  );
+  const projectedMonthlySpend = useMemo(
+    () => spendingAnalysis.monthlyAverage - projectedMonthlySavings,
+    [spendingAnalysis.monthlyAverage, projectedMonthlySavings]
+  );
+  const projectedAnnualSavings = useMemo(() => projectedMonthlySavings * 12, [projectedMonthlySavings]);
+
+  const upcomingRecurring = useMemo(() => {
+    const today = new Date();
+    const nextRecurring = recurringExpenses
+      .map((expense) => {
+        const scheduledDate = parseISO(expense.nextDueDate ?? expense.dueDate);
+        return {
+          ...expense,
+          scheduledDate
+        };
+      })
+      .filter((expense) => isValid(expense.scheduledDate))
+      .sort((a, b) => a.scheduledDate.getTime() - b.scheduledDate.getTime())[0];
+
+    if (!nextRecurring) {
+      return null;
+    }
+
+    const daysUntil = differenceInCalendarDays(nextRecurring.scheduledDate, today);
+    const dueLabel =
+      daysUntil === 0
+        ? 'Due today'
+        : daysUntil === 1
+        ? 'Due tomorrow'
+        : daysUntil > 1
+        ? `Due in ${daysUntil} days`
+        : `Overdue by ${Math.abs(daysUntil)} days`;
+
+    return {
+      name: nextRecurring.name,
+      amount: currencyFormatter.format(nextRecurring.amount),
+      dueLabel,
+      dateLabel: format(nextRecurring.scheduledDate, 'dd MMM yyyy')
+    };
+  }, [recurringExpenses, currencyFormatter]);
+
+  const plannedExpenseSummary = useMemo(() => {
+    const pendingExpenses = plannedExpenses.filter((expense) => expense.status === 'pending');
+    const totalPending = pendingExpenses.reduce((sum, item) => sum + item.plannedAmount, 0);
+
+    const nextExpense = pendingExpenses
+      .map((expense) => {
+        const scheduledDate = parseISO(expense.dueDate);
+        return {
+          ...expense,
+          scheduledDate
+        };
+      })
+      .filter((expense) => isValid(expense.scheduledDate))
+      .sort((a, b) => a.scheduledDate.getTime() - b.scheduledDate.getTime())[0];
+
+    return {
+      totalPending,
+      nextExpense: nextExpense
+        ? {
+            name: nextExpense.name,
+            dateLabel: format(nextExpense.scheduledDate, 'dd MMM'),
+            daysUntil: differenceInCalendarDays(nextExpense.scheduledDate, new Date())
+          }
+        : null
+    };
+  }, [plannedExpenses]);
+
+  const actionableTiles = useMemo(() => {
+    return [
+      {
+        id: 'tile-upcoming-recurring',
+        title: 'Upcoming recurring payment',
+        primaryText: upcomingRecurring ? upcomingRecurring.name : 'No recurring debits due soon',
+        metric: upcomingRecurring?.amount,
+        caption: upcomingRecurring
+          ? `${upcomingRecurring.dueLabel} · ${upcomingRecurring.dateLabel}`
+          : 'You are up to date on recurring commitments.'
+      },
+      {
+        id: 'tile-planned-expense-review',
+        title: 'Review planned variable expenses',
+        primaryText:
+          plannedExpenseSummary.totalPending > 0
+            ? `${plannedExpenseSummary.nextExpense?.name ?? 'Pending purchases'}`
+            : 'All planned items reconciled',
+        metric:
+          plannedExpenseSummary.totalPending > 0
+            ? currencyFormatter.format(plannedExpenseSummary.totalPending)
+            : undefined,
+        caption:
+          plannedExpenseSummary.totalPending > 0
+            ? plannedExpenseSummary.nextExpense
+              ? `${plannedExpenseSummary.nextExpense.daysUntil <= 0 ? 'Due now' : `Next on ${plannedExpenseSummary.nextExpense.dateLabel}`}`
+              : 'Review timelines to balance cash flow.'
+            : 'Great job staying on top of planned spending.'
+      }
+    ];
+  }, [upcomingRecurring, plannedExpenseSummary, currencyFormatter]);
 
   return (
     <div className="space-y-6">
@@ -11,6 +187,12 @@ export function InsightsView() {
       </header>
 
       <section className="space-y-3">
+        <div className="grid gap-3 sm:grid-cols-2">
+          {actionableTiles.map((tile) => (
+            <ActionTile key={tile.id} title={tile.title} primaryText={tile.primaryText} metric={tile.metric} caption={tile.caption} />
+          ))}
+        </div>
+
         {insights.map((insight) => (
           <article
             key={insight.id}
@@ -23,11 +205,136 @@ export function InsightsView() {
               </span>
             </header>
             <p className="mt-3 text-slate-300">{insight.description}</p>
+            {insight.metricSummary && (
+              <dl className="mt-4 rounded-xl border border-slate-800 bg-slate-900/70 p-4 text-xs text-slate-300">
+                <dt className="font-semibold text-slate-200">{insight.metricSummary.label}</dt>
+                <dd className="mt-1 text-base font-semibold text-accent">{insight.metricSummary.value}</dd>
+                {insight.metricSummary.helperText && (
+                  <dd className="mt-1 text-[11px] text-slate-500">{insight.metricSummary.helperText}</dd>
+                )}
+              </dl>
+            )}
+            {insight.projection && (
+              <div className="mt-4 grid gap-4 rounded-xl border border-slate-800 bg-slate-900/70 p-4 text-xs text-slate-300 sm:grid-cols-3">
+                <div>
+                  <p className="text-[11px] uppercase tracking-wide text-slate-500">Current</p>
+                  <p className="mt-1 text-base font-semibold text-slate-100">
+                    {formatProjectionValue(insight.projection.currentValue, insight.projection.unit, currencyFormatter, percentageFormatter)}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-[11px] uppercase tracking-wide text-slate-500">Projected</p>
+                  <p className="mt-1 text-base font-semibold text-slate-100">
+                    {formatProjectionValue(insight.projection.projectedValue, insight.projection.unit, currencyFormatter, percentageFormatter)}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-[11px] uppercase tracking-wide text-slate-500">Timeframe</p>
+                  <p className="mt-1 text-base font-semibold text-slate-100">{insight.projection.timeframe}</p>
+                </div>
+                <p className="sm:col-span-3 text-[11px] text-slate-400">{insight.projection.description}</p>
+              </div>
+            )}
+            {insight.recommendations && insight.recommendations.length > 0 && (
+              <div className="mt-4">
+                <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Next best actions</p>
+                <ul className="mt-2 space-y-2 text-slate-300">
+                  {insight.recommendations.map((recommendation, index) => (
+                    <li key={index} className="flex items-start gap-2">
+                      <span className="mt-1 inline-flex h-1.5 w-1.5 rounded-full bg-accent" aria-hidden />
+                      <span>{recommendation}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
           </article>
         ))}
         {insights.length === 0 && (
           <p className="text-sm text-slate-500">Insights will appear after analysing your transactions.</p>
         )}
+      </section>
+
+      <section className="rounded-2xl border border-slate-800 bg-slate-950/60 p-5 text-sm shadow">
+        <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h3 className="text-base font-semibold text-slate-100">Spending scenario planner</h3>
+            <p className="mt-1 text-xs text-slate-400">
+              Model a quick rule to see how discretionary tweaks change your monthly cash flow.
+            </p>
+          </div>
+          {spendingAnalysis.monthsTracked > 0 && (
+            <p className="text-[11px] uppercase tracking-wide text-slate-500">
+              {spendingAnalysis.monthsTracked} month{spendingAnalysis.monthsTracked === 1 ? '' : 's'} of history analysed
+            </p>
+          )}
+        </header>
+
+        <div className="mt-4 grid gap-4 sm:grid-cols-3">
+          <MetricTile
+            label="Average monthly spend"
+            value={currencyFormatter.format(spendingAnalysis.monthlyAverage)}
+            caption="Across all expense categories"
+          />
+          <MetricTile
+            label={`Rule impact (${ruleReduction}% cut)`}
+            value={currencyFormatter.format(projectedMonthlySavings)}
+            caption="Potential monthly savings"
+          />
+          <MetricTile
+            label="Projected monthly spend"
+            value={currencyFormatter.format(Math.max(projectedMonthlySpend, 0))}
+            caption="After applying the rule"
+          />
+        </div>
+
+        <div className="mt-6">
+          <label htmlFor="rule-reduction" className="flex justify-between text-xs text-slate-300">
+            <span>Reduction rule</span>
+            <span className="font-semibold text-accent">{ruleReduction}% less discretionary spend</span>
+          </label>
+          <input
+            id="rule-reduction"
+            type="range"
+            min={0}
+            max={50}
+            step={5}
+            value={ruleReduction}
+            onChange={(event) => setRuleReduction(Number(event.target.value))}
+            className="mt-2 h-2 w-full cursor-pointer appearance-none rounded-full bg-slate-800 accent-accent"
+          />
+          <p className="mt-2 text-xs text-slate-400">
+            Annualised, this adds up to {currencyFormatter.format(projectedAnnualSavings)} you can redirect towards investments or
+            debt payoff.
+          </p>
+        </div>
+
+        <div className="mt-6">
+          <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Top spending levers</h4>
+          <ul className="mt-3 space-y-3">
+            {spendingAnalysis.topCategories.map((category) => (
+              <li key={category.id} className="rounded-xl border border-slate-800 bg-slate-900/60 p-3">
+                <div className="flex items-center justify-between text-sm">
+                  <p className="font-medium text-slate-100">{category.name}</p>
+                  <p className="text-xs text-slate-400">
+                    {currencyFormatter.format(category.monthlyAverage)} · {percentageFormatter.format(category.share)} of monthly spend
+                  </p>
+                </div>
+                <div className="mt-2 h-1.5 w-full rounded-full bg-slate-800">
+                  <div
+                    className="h-full rounded-full bg-accent"
+                    style={{ width: `${Math.min(category.share * 100, 100)}%` }}
+                  />
+                </div>
+              </li>
+            ))}
+            {spendingAnalysis.topCategories.length === 0 && (
+              <li className="rounded-xl border border-dashed border-slate-800 bg-slate-900/20 p-4 text-xs text-slate-400">
+                Start categorising expenses to uncover the biggest levers for quick savings wins.
+              </li>
+            )}
+          </ul>
+        </div>
       </section>
     </div>
   );
@@ -42,4 +349,57 @@ function badgeClasses(severity: 'info' | 'warning' | 'critical') {
     default:
       return 'bg-accent/20 text-accent';
   }
+}
+
+function formatProjectionValue(
+  value: number,
+  unit: 'currency' | 'percentage',
+  currencyFormatter: Intl.NumberFormat,
+  percentageFormatter: Intl.NumberFormat
+) {
+  if (unit === 'percentage') {
+    return percentageFormatter.format(value / 100);
+  }
+  return currencyFormatter.format(value);
+}
+
+function MetricTile({
+  label,
+  value,
+  caption
+}: {
+  label: string;
+  value: string;
+  caption?: string;
+}) {
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+      <p className="text-[11px] uppercase tracking-wide text-slate-500">{label}</p>
+      <p className="mt-2 text-lg font-semibold text-slate-100">{value}</p>
+      {caption && <p className="mt-1 text-xs text-slate-500">{caption}</p>}
+    </div>
+  );
+}
+
+function ActionTile({
+  title,
+  primaryText,
+  metric,
+  caption
+}: {
+  title: string;
+  primaryText: string;
+  metric?: string;
+  caption?: string;
+}) {
+  return (
+    <article className="rounded-2xl border border-slate-800 bg-slate-900/40 p-4 text-sm shadow-sm">
+      <header className="flex items-center justify-between gap-3">
+        <h3 className="text-sm font-semibold text-slate-100">{title}</h3>
+        {metric && <span className="text-sm font-semibold text-accent">{metric}</span>}
+      </header>
+      <p className="mt-2 text-base font-medium text-slate-200">{primaryText}</p>
+      {caption && <p className="mt-1 text-xs text-slate-400">{caption}</p>}
+    </article>
+  );
 }


### PR DESCRIPTION
## Summary
- allow the initial ledger setup dialog to be skipped and reopened later with a resume control in the app header
- persist the dismissal state across reloads while preventing leading zeroes in opening balance inputs during setup
- tighten the savings rate gauge styling so the percentage stays within the circular progress ring

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e12098b11c832c9e31c98586f91ef3