### PR TITLE
Adjust account balances when recording manual transactions

### DIFF
--- a/src/store/FinancialStoreProvider.tsx
+++ b/src/store/FinancialStoreProvider.tsx
@@ -640,10 +640,30 @@ export function FinancialStoreProvider({ children }: { children: ReactNode }) {
       createdAt: now,
       updatedAt: now
     };
-    await persistAndSet((snapshot) => ({
-      ...snapshot,
-      transactions: [...snapshot.transactions, transaction]
-    }));
+    let accountUpdated = false;
+    await persistAndSet((snapshot) => {
+      const account = snapshot.accounts.find((item) => item.id === transaction.accountId);
+      if (!account) {
+        return snapshot;
+      }
+      accountUpdated = true;
+      return {
+        ...snapshot,
+        accounts: snapshot.accounts.map((item) =>
+          item.id === transaction.accountId
+            ? {
+                ...item,
+                balance: item.balance + transaction.amount,
+                updatedAt: now
+              }
+            : item
+        ),
+        transactions: [...snapshot.transactions, transaction]
+      };
+    });
+    if (!accountUpdated) {
+      throw new Error('Unable to record spend: the selected account no longer exists.');
+    }
     return transaction;
   };
 


### PR DESCRIPTION
## Summary
- update manual transaction logging to also adjust the linked account balance
- guard against logging spends for accounts that no longer exist so the UI stays consistent

## Testing
- npm test *(fails: vitest timed out in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e12ebfd5d0832c8eeac233b7b85246