### PR TITLE
Fix planned expense navigator filter logic

### DIFF
--- a/src/views/SmartBudgetingView.tsx
+++ b/src/views/SmartBudgetingView.tsx
@@ -917,7 +917,7 @@ export function SmartBudgetingView() {
     const varianceLabel = summary.variance >= 0 ? 'Saved' : 'Overspent';
     const varianceDisplay = Math.abs(summary.variance);
     const matchesCategorySearch =
-      normalisedSearchTerm === '' || category.name.toLowerCase().includes(normalisedSearchTerm);
+      normalisedSearchTerm !== '' && category.name.toLowerCase().includes(normalisedSearchTerm);
     const visibleDirectItems = directItems.filter((detail) => {
       const matchesStatus = navigatorFilter === 'all' || detail.status === navigatorFilter;
       const matchesName =


### PR DESCRIPTION
## Summary
- ensure the navigator only treats a category as a search match when a term is provided so status filters hide unmatched categories

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e145ff7fb8832c8b582a8886eb4049