### PR TITLE
Ensure planned expenses default to active budgeting period

### DIFF
--- a/src/views/SmartBudgetingView.tsx
+++ b/src/views/SmartBudgetingView.tsx
@@ -58,11 +58,25 @@ export function SmartBudgetingView() {
 
   const generateEntryId = () => Math.random().toString(36).slice(2);
 
+  const resolveDefaultDueDate = () => {
+    try {
+      if (viewMode === 'monthly') {
+        return formatISO(parseISO(`${selectedMonth}-01`), { representation: 'date' });
+      }
+      if (viewMode === 'yearly') {
+        return formatISO(parseISO(`${selectedYear}-01-01`), { representation: 'date' });
+      }
+    } catch {
+      // Fall through to the generic fallback below when parsing fails.
+    }
+    return formatISO(addMonths(new Date(), 1), { representation: 'date' });
+  };
+
   const createEmptyEntry = (categoryId?: string): PlannedExpenseDraft => ({
     id: generateEntryId(),
     name: '',
     amount: '',
-    dueDate: formatISO(addMonths(new Date(), 1), { representation: 'date' }),
+    dueDate: resolveDefaultDueDate(),
     categoryId: categoryId ?? expenseCategories[0]?.id ?? ''
   });
 


### PR DESCRIPTION
## Summary
- align the default due date for new planned expense entries with the currently selected budgeting period
- fall back to the next month when the selected period cannot be parsed so the dialog still works in edge cases

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e14c9c691c832c938fbaf71d4af609