### PR TITLE
Add budget draft state for SmartBudgetingView

### DIFF
--- a/src/views/SmartBudgetingView.tsx
+++ b/src/views/SmartBudgetingView.tsx
@@ -324,6 +324,7 @@ export function SmartBudgetingView() {
   const [navigatorFilter, setNavigatorFilter] = useState<'all' | PlannedExpenseSpendingHealth>('all');
   const [categorySearchTerm, setCategorySearchTerm] = useState('');
   const [focusedCategoryId, setFocusedCategoryId] = useState<string | null>(null);
+  const [budgetDraft, setBudgetDraft] = useState('');
   const navigatorFilterOptions: Array<{ key: 'all' | PlannedExpenseSpendingHealth; label: string }> = [
     { key: 'all', label: 'All statuses' },
     { key: 'over', label: 'Overspending' },


### PR DESCRIPTION
## Summary
- add a budget draft state hook alongside the other SmartBudgetingView state to back the budget baseline effect

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e20579c018832c92c04054772de56f