### PR TITLE
Add priority planned expense navigator with remainder controls

### DIFF
--- a/src/services/insightsEngine.ts
+++ b/src/services/insightsEngine.ts
@@ -84,10 +84,13 @@ export function generateInsights(input: InsightInput): Insight[] {
   }
 
   const nextRecurring = input.recurringExpenses
-    .map((expense) => ({
-      ...expense,
-      dueIn: differenceInMonths(parseISO(expense.nextDueDate ?? expense.dueDate), new Date())
-    }))
+    .map((expense) => {
+      const referenceDate = expense.nextDueDate ?? expense.dueDate ?? expense.createdAt;
+      return {
+        ...expense,
+        dueIn: differenceInMonths(parseISO(referenceDate), new Date())
+      };
+    })
     .sort((a, b) => a.dueIn - b.dueIn)[0];
 
   if (nextRecurring) {

--- a/src/services/wealthAcceleratorEngine.ts
+++ b/src/services/wealthAcceleratorEngine.ts
@@ -28,7 +28,10 @@ export function simulateWealthAccelerator(
   );
 
   const upcomingRecurring = recurringExpenses
-    .map((expense) => differenceInMonths(parseISO(expense.nextDueDate ?? expense.dueDate), new Date()))
+    .map((expense) => {
+      const referenceDate = expense.nextDueDate ?? expense.dueDate ?? expense.createdAt;
+      return differenceInMonths(parseISO(referenceDate), new Date());
+    })
     .filter((diff) => diff >= 0)
     .sort((a, b) => a - b)[0];
 

--- a/src/store/FinancialStoreProvider.tsx
+++ b/src/store/FinancialStoreProvider.tsx
@@ -55,6 +55,13 @@ const sanitiseBudgets = (budgets?: Category['budgets']): Category['budgets'] | u
   return Object.keys(normalised).length ? normalised : undefined;
 };
 
+const normaliseOptionalNumber = (value: number | null | undefined): number | null => {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return null;
+  }
+  return value;
+};
+
 interface InitialSetupPayload {
   currency: Profile['currency'];
   financialStartDate: string;
@@ -547,6 +554,9 @@ export function FinancialStoreProvider({ children }: { children: ReactNode }) {
       ...payload,
       id: crypto.randomUUID(),
       status: payload.status ?? 'pending',
+      priority: payload.priority ?? 'medium',
+      remainderAmount: normaliseOptionalNumber(payload.remainderAmount),
+      dueDate: payload.dueDate ?? null,
       createdAt: now,
       updatedAt: now
     };
@@ -565,6 +575,11 @@ export function FinancialStoreProvider({ children }: { children: ReactNode }) {
           ? {
               ...expense,
               ...payload,
+              ...(payload.priority === undefined ? {} : { priority: payload.priority ?? 'medium' }),
+              ...(payload.dueDate === undefined ? {} : { dueDate: payload.dueDate ?? null }),
+              ...(payload.remainderAmount === undefined
+                ? {}
+                : { remainderAmount: normaliseOptionalNumber(payload.remainderAmount) }),
               updatedAt: new Date().toISOString()
             }
           : expense

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -58,7 +58,9 @@ export interface PlannedExpenseItem extends Timestamped {
   plannedAmount: number;
   actualAmount?: number;
   categoryId: string;
-  dueDate: string;
+  dueDate?: string | null;
+  priority: 'low' | 'medium' | 'high';
+  remainderAmount?: number | null;
   status: 'pending' | 'purchased' | 'cancelled' | 'reconciled';
   notes?: string;
 }

--- a/src/views/GoalSimulatorView.tsx
+++ b/src/views/GoalSimulatorView.tsx
@@ -142,6 +142,7 @@ function GoalCreator() {
       plannedAmount: form.amount / 12,
       categoryId: category.id,
       dueDate: form.targetDate,
+      priority: 'medium',
       status: 'pending'
     });
     setForm((prev) => ({ ...prev, name: '', amount: 0 }));

--- a/src/views/IncomeManagementView.tsx
+++ b/src/views/IncomeManagementView.tsx
@@ -44,12 +44,12 @@ function createBlankDraft(type: Category['type'] = 'income'): CategoryDraftForm 
   };
 }
 
-function monthKey(date: string) {
-  return date.slice(0, 7);
+function monthKey(date?: string | null) {
+  return date ? date.slice(0, 7) : '';
 }
 
-function yearKey(date: string) {
-  return date.slice(0, 4);
+function yearKey(date?: string | null) {
+  return date ? date.slice(0, 4) : '';
 }
 
 function buildCategoryTree(categories: Category[]): CategoryNode[] {
@@ -179,14 +179,14 @@ export function IncomeManagementView() {
   const categoryMonthOptions = useMemo(() => {
     const months = new Set<string>([selectedCategoryMonth, defaultMonth]);
     transactions.forEach((txn) => months.add(monthKey(txn.date)));
-    plannedExpenses.forEach((item) => months.add(monthKey(item.dueDate)));
+    plannedExpenses.forEach((item) => months.add(monthKey(item.dueDate ?? item.createdAt)));
     return Array.from(months).sort((a, b) => (a > b ? -1 : 1));
   }, [transactions, plannedExpenses, selectedCategoryMonth, defaultMonth]);
 
   const categoryYearOptions = useMemo(() => {
     const years = new Set<string>([selectedCategoryYear, defaultYear]);
     transactions.forEach((txn) => years.add(yearKey(txn.date)));
-    plannedExpenses.forEach((item) => years.add(yearKey(item.dueDate)));
+    plannedExpenses.forEach((item) => years.add(yearKey(item.dueDate ?? item.createdAt)));
     return Array.from(years).sort((a, b) => (a > b ? -1 : 1));
   }, [transactions, plannedExpenses, selectedCategoryYear, defaultYear]);
 
@@ -258,8 +258,8 @@ export function IncomeManagementView() {
     () =>
       plannedExpenses.filter((item) =>
         categoryViewMode === 'monthly'
-          ? monthKey(item.dueDate) === selectedCategoryMonth
-          : yearKey(item.dueDate) === selectedCategoryYear
+          ? monthKey(item.dueDate ?? item.createdAt) === selectedCategoryMonth
+          : yearKey(item.dueDate ?? item.createdAt) === selectedCategoryYear
       ),
     [plannedExpenses, categoryViewMode, selectedCategoryMonth, selectedCategoryYear]
   );
@@ -322,7 +322,19 @@ export function IncomeManagementView() {
         }
 
         transactionsList.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
-        plannedList.sort((a, b) => new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime());
+        plannedList.sort((a, b) => {
+          const hasDueA = Boolean(a.dueDate);
+          const hasDueB = Boolean(b.dueDate);
+          if (hasDueA && hasDueB) {
+            const diff = new Date(a.dueDate!).getTime() - new Date(b.dueDate!).getTime();
+            if (diff !== 0) {
+              return diff;
+            }
+          } else if (hasDueA !== hasDueB) {
+            return hasDueA ? -1 : 1;
+          }
+          return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+        });
 
         return {
           totalSpent,
@@ -767,7 +779,10 @@ export function IncomeManagementView() {
                         <li key={item.id} className="flex justify-between rounded-lg bg-slate-900/80 px-3 py-2">
                           <span>{item.description}</span>
                           <span className="font-semibold text-warning">
-                            {formatCurrency(item.plannedAmount)} on {format(parseISO(item.dueDate), 'dd MMM yyyy')}
+                            {formatCurrency(item.plannedAmount)}{' '}
+                            {item.dueDate
+                              ? `on ${format(parseISO(item.dueDate), 'dd MMM yyyy')}`
+                              : '— no due date'}
                           </span>
                         </li>
                       ))}

--- a/src/views/InsightsView.tsx
+++ b/src/views/InsightsView.tsx
@@ -89,7 +89,7 @@ export function InsightsView() {
     const today = new Date();
     const nextRecurring = recurringExpenses
       .map((expense) => {
-        const scheduledDate = parseISO(expense.nextDueDate ?? expense.dueDate);
+        const scheduledDate = parseISO(expense.nextDueDate ?? expense.dueDate ?? expense.createdAt);
         return {
           ...expense,
           scheduledDate
@@ -125,8 +125,9 @@ export function InsightsView() {
     const totalPending = pendingExpenses.reduce((sum, item) => sum + item.plannedAmount, 0);
 
     const nextExpense = pendingExpenses
+      .filter((expense) => Boolean(expense.dueDate))
       .map((expense) => {
-        const scheduledDate = parseISO(expense.dueDate);
+        const scheduledDate = parseISO(expense.dueDate!);
         return {
           ...expense,
           scheduledDate

--- a/src/views/SmartBudgetingView.tsx
+++ b/src/views/SmartBudgetingView.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react';
-import { format, formatISO, parseISO } from 'date-fns';
+import { addMonths, format, formatISO, parseISO } from 'date-fns';
 import { useFinancialStore } from '../store/FinancialStoreProvider';
 import type { Category, PlannedExpenseItem, Transaction } from '../types';
 
@@ -7,12 +7,12 @@ function formatCurrency(value: number) {
   return new Intl.NumberFormat('en-IN', { style: 'currency', currency: 'INR', maximumFractionDigits: 0 }).format(value);
 }
 
-function monthKey(date: string) {
-  return date.slice(0, 7);
+function monthKey(date?: string | null) {
+  return date ? date.slice(0, 7) : '';
 }
 
-function yearKey(date: string) {
-  return date.slice(0, 4);
+function yearKey(date?: string | null) {
+  return date ? date.slice(0, 4) : '';
 }
 
 function formatMonthLabel(month: string) {
@@ -46,6 +46,20 @@ function defaultDueDateForPeriod(viewMode: 'monthly' | 'yearly', month: string, 
   return formatISO(defaultDate, { representation: 'date' });
 }
 
+const PRIORITY_TOKEN_STYLES: Record<PlannedExpenseItem['priority'], { label: string; badgeClass: string }> = {
+  high: { label: 'High priority', badgeClass: 'bg-danger/20 text-danger' },
+  medium: { label: 'Medium priority', badgeClass: 'bg-warning/20 text-warning' },
+  low: { label: 'Low priority', badgeClass: 'bg-slate-800 text-slate-300' }
+};
+
+const PRIORITY_OPTIONS: Array<{ value: PlannedExpenseItem['priority']; label: string }> = [
+  { value: 'high', label: 'High priority' },
+  { value: 'medium', label: 'Medium priority' },
+  { value: 'low', label: 'Low priority' }
+];
+
+const PRIORITY_ORDER: PlannedExpenseItem['priority'][] = ['high', 'medium', 'low'];
+
 export function SmartBudgetingView() {
   const {
     plannedExpenses,
@@ -76,7 +90,9 @@ export function SmartBudgetingView() {
     name: string;
     amount: string;
     dueDate: string;
+    hasDueDate: boolean;
     categoryId: string;
+    priority: PlannedExpenseItem['priority'];
   };
 
   const generateEntryId = () => Math.random().toString(36).slice(2);
@@ -100,7 +116,9 @@ export function SmartBudgetingView() {
     name: '',
     amount: '',
     dueDate: resolveDefaultDueDate(),
-    categoryId: categoryId ?? expenseCategories[0]?.id ?? ''
+    hasDueDate: true,
+    categoryId: categoryId ?? expenseCategories[0]?.id ?? '',
+    priority: 'medium'
   });
 
   const [plannedEntries, setPlannedEntries] = useState<PlannedExpenseDraft[]>(() => [createEmptyEntry()]);
@@ -178,7 +196,7 @@ export function SmartBudgetingView() {
 
   const categoryMonthOptions = useMemo(() => {
     const months = new Set<string>([selectedMonth, defaultMonth]);
-    plannedExpenses.forEach((item) => months.add(monthKey(item.dueDate)));
+    plannedExpenses.forEach((item) => months.add(monthKey(item.dueDate ?? item.createdAt)));
     transactions
       .filter((txn) => txn.amount < 0)
       .forEach((txn) => months.add(monthKey(txn.date)));
@@ -187,7 +205,7 @@ export function SmartBudgetingView() {
 
   const categoryYearOptions = useMemo(() => {
     const years = new Set<string>([selectedYear, defaultYear]);
-    plannedExpenses.forEach((item) => years.add(yearKey(item.dueDate)));
+    plannedExpenses.forEach((item) => years.add(yearKey(item.dueDate ?? item.createdAt)));
     transactions
       .filter((txn) => txn.amount < 0)
       .forEach((txn) => years.add(yearKey(txn.date)));
@@ -196,11 +214,15 @@ export function SmartBudgetingView() {
 
   const periodPlannedExpenses = useMemo(
     () =>
-      plannedExpenses.filter(
-        (item) =>
-          item.status !== 'cancelled' &&
-          (viewMode === 'monthly' ? monthKey(item.dueDate) === selectedMonth : yearKey(item.dueDate) === selectedYear)
-      ),
+      plannedExpenses.filter((item) => {
+        if (item.status === 'cancelled') {
+          return false;
+        }
+        const referenceDate = item.dueDate ?? item.createdAt;
+        return viewMode === 'monthly'
+          ? monthKey(referenceDate) === selectedMonth
+          : yearKey(referenceDate) === selectedYear;
+      }),
     [plannedExpenses, viewMode, selectedMonth, selectedYear]
   );
 
@@ -261,19 +283,34 @@ export function SmartBudgetingView() {
     actual: number;
     variance: number;
     status: PlannedExpenseSpendingHealth;
+    remainder: number;
+    priority: PlannedExpenseItem['priority'];
   };
 
   type CategoryNode = Category & { children: CategoryNode[] };
 
   const [expandedCategories, setExpandedCategories] = useState<Record<string, boolean>>({});
   const [editingItemId, setEditingItemId] = useState<string | null>(null);
-  const [editDraft, setEditDraft] = useState<{ categoryId: string; plannedAmount: string; actualAmount: string }>({
+  const [editDraft, setEditDraft] = useState<{
+    categoryId: string;
+    plannedAmount: string;
+    actualAmount: string;
+    remainderAmount: string;
+    dueDate: string;
+    hasDueDate: boolean;
+    priority: PlannedExpenseItem['priority'];
+  }>({
     categoryId: '',
     plannedAmount: '',
-    actualAmount: ''
+    actualAmount: '',
+    remainderAmount: '',
+    dueDate: '',
+    hasDueDate: true,
+    priority: 'medium'
   });
   const [savingItemId, setSavingItemId] = useState<string | null>(null);
   const [navigatorFilter, setNavigatorFilter] = useState<'all' | PlannedExpenseSpendingHealth>('all');
+  const [navigatorView, setNavigatorView] = useState<'category' | 'priority'>('category');
   const [categorySearchTerm, setCategorySearchTerm] = useState('');
   const [focusedCategoryId, setFocusedCategoryId] = useState<string | null>(null);
   const [budgetDraft, setBudgetDraft] = useState('');
@@ -283,6 +320,10 @@ export function SmartBudgetingView() {
     { key: 'over', label: 'Overspending' },
     { key: 'under', label: 'Under budget' },
     { key: 'not-spent', label: 'Awaiting spend' }
+  ];
+  const navigatorViewOptions: Array<{ key: 'category' | 'priority'; label: string }> = [
+    { key: 'category', label: 'Category view' },
+    { key: 'priority', label: 'Priority view' }
   ];
   const normalisedSearchTerm = categorySearchTerm.trim().toLowerCase();
 
@@ -308,22 +349,46 @@ export function SmartBudgetingView() {
             Math.abs(Math.abs(txn.amount) - item.plannedAmount) <= Math.max(500, item.plannedAmount * 0.1)
         );
         const matchedAmount = match ? Math.abs(match.amount) : 0;
+        const manualActual =
+          typeof item.actualAmount === 'number' && !Number.isNaN(item.actualAmount) ? item.actualAmount : undefined;
+        const remainderOverride =
+          typeof item.remainderAmount === 'number' && !Number.isNaN(item.remainderAmount)
+            ? Math.max(item.remainderAmount, 0)
+            : null;
         const actualAmount =
-          typeof item.actualAmount === 'number' && !Number.isNaN(item.actualAmount)
-            ? item.actualAmount
-            : matchedAmount;
+          manualActual ??
+          (remainderOverride !== null ? Math.max(item.plannedAmount - remainderOverride, 0) : matchedAmount);
         const variance = item.plannedAmount - actualAmount;
+        const remainder = remainderOverride !== null ? remainderOverride : variance;
         const status: PlannedExpenseSpendingHealth =
           actualAmount === 0 ? 'not-spent' : variance >= 0 ? 'under' : 'over';
         return {
-          item,
+          item: { ...item, priority: item.priority ?? 'medium' },
           match,
           actual: actualAmount,
           variance,
-          status
+          status,
+          remainder,
+          priority: item.priority ?? 'medium'
         } satisfies PlannedExpenseDetail;
       })
-      .sort((a, b) => new Date(a.item.dueDate).getTime() - new Date(b.item.dueDate).getTime());
+      .sort((a, b) => {
+        const hasDueA = Boolean(a.item.dueDate);
+        const hasDueB = Boolean(b.item.dueDate);
+        if (hasDueA && hasDueB) {
+          const diff = new Date(a.item.dueDate!).getTime() - new Date(b.item.dueDate!).getTime();
+          if (diff !== 0) {
+            return diff;
+          }
+        } else if (hasDueA !== hasDueB) {
+          return hasDueA ? -1 : 1;
+        }
+        const createdDiff = new Date(a.item.createdAt).getTime() - new Date(b.item.createdAt).getTime();
+        if (createdDiff !== 0) {
+          return createdDiff;
+        }
+        return a.item.name.localeCompare(b.item.name);
+      });
   }, [periodPlannedExpenses, periodTransactions]);
 
   const expenseCategoryTree = useMemo<CategoryNode[]>(() => {
@@ -374,13 +439,14 @@ export function SmartBudgetingView() {
 
     const summaries = new Map<
       string,
-      { planned: number; actual: number; variance: number; itemCount: number }
+      { planned: number; actual: number; variance: number; itemCount: number; remainder: number }
     >();
 
     expenseCategories.forEach((category) => {
       const ids = expenseDescendantsMap.get(category.id) ?? new Set<string>([category.id]);
       let planned = 0;
       let actual = 0;
+      let remainder = 0;
       let itemCount = 0;
       ids.forEach((id) => {
         const entries = byCategory.get(id);
@@ -389,13 +455,15 @@ export function SmartBudgetingView() {
         entries.forEach((detail) => {
           planned += detail.item.plannedAmount;
           actual += detail.actual;
+          remainder += detail.remainder;
         });
       });
       summaries.set(category.id, {
         planned,
         actual,
         variance: planned - actual,
-        itemCount
+        itemCount,
+        remainder
       });
     });
 
@@ -482,6 +550,46 @@ export function SmartBudgetingView() {
     [uncategorisedDetails, navigatorFilter, normalisedSearchTerm]
   );
 
+  const filteredPriorityDetails = useMemo(() => {
+    return plannedExpenseDetails.filter((detail) => {
+      const matchesFilter = navigatorFilter === 'all' || detail.status === navigatorFilter;
+      if (!matchesFilter) {
+        return false;
+      }
+      if (normalisedSearchTerm === '') {
+        return true;
+      }
+      const categoryName = categoryLookup.get(detail.item.categoryId)?.name?.toLowerCase() ?? 'uncategorised';
+      return (
+        detail.item.name.toLowerCase().includes(normalisedSearchTerm) || categoryName.includes(normalisedSearchTerm)
+      );
+    });
+  }, [plannedExpenseDetails, navigatorFilter, normalisedSearchTerm, categoryLookup]);
+
+  const priorityGroups = useMemo(() => {
+    const groups: Record<PlannedExpenseItem['priority'], PlannedExpenseDetail[]> = {
+      high: [],
+      medium: [],
+      low: []
+    };
+    const timeForDetail = (detail: PlannedExpenseDetail) =>
+      detail.item.dueDate ? new Date(detail.item.dueDate).getTime() : Number.POSITIVE_INFINITY;
+    filteredPriorityDetails.forEach((detail) => {
+      const priority = detail.priority ?? 'medium';
+      groups[priority].push(detail);
+    });
+    PRIORITY_ORDER.forEach((priority) => {
+      groups[priority].sort((a, b) => {
+        const dueComparison = timeForDetail(a) - timeForDetail(b);
+        if (dueComparison !== 0) {
+          return dueComparison;
+        }
+        return a.item.name.localeCompare(b.item.name);
+      });
+    });
+    return groups;
+  }, [filteredPriorityDetails]);
+
   const overallSummary = useMemo(() => {
     const planned = plannedExpenseDetails.reduce((sum, detail) => sum + detail.item.plannedAmount, 0);
     const actual = plannedExpenseDetails.reduce((sum, detail) => sum + detail.actual, 0);
@@ -518,6 +626,9 @@ export function SmartBudgetingView() {
       : 'over'
     : null;
   const inspectorStatusToken = inspectorStatus ? spendingBadgeStyles[inspectorStatus] : null;
+  const inspectorRemainderValue = inspectorSummary?.remainder ?? 0;
+  const inspectorRemainderClass = inspectorRemainderValue >= 0 ? 'text-success' : 'text-danger';
+  const inspectorRemainderLabel = inspectorRemainderValue >= 0 ? 'Remaining budget' : 'Overspent';
   const inspectorDetails = useMemo(() => {
     if (!focusedCategoryId) {
       return [] as PlannedExpenseDetail[];
@@ -531,8 +642,10 @@ export function SmartBudgetingView() {
     return overs.slice(0, 3);
   }, [inspectorDetails]);
   const inspectorUpcomingItems = useMemo(() => {
-    const upcoming = inspectorDetails.filter((detail) => detail.status !== 'over');
-    upcoming.sort((a, b) => new Date(a.item.dueDate).getTime() - new Date(b.item.dueDate).getTime());
+    const upcoming = inspectorDetails.filter(
+      (detail) => detail.status !== 'over' && detail.item.dueDate
+    );
+    upcoming.sort((a, b) => new Date(a.item.dueDate!).getTime() - new Date(b.item.dueDate!).getTime());
     return upcoming.slice(0, 3);
   }, [inspectorDetails]);
   const isBudgetDraftInvalid =
@@ -583,7 +696,7 @@ export function SmartBudgetingView() {
     if (entry.amount.trim() === '') return false;
     const numericAmount = Number(entry.amount);
     if (Number.isNaN(numericAmount) || numericAmount < 0) return false;
-    if (!entry.dueDate) return false;
+    if (entry.hasDueDate && !entry.dueDate) return false;
     if (!entry.categoryId) return false;
     return true;
   };
@@ -631,7 +744,8 @@ export function SmartBudgetingView() {
           name: entry.name.trim(),
           plannedAmount: Number(entry.amount),
           categoryId: entry.categoryId,
-          dueDate: entry.dueDate,
+          dueDate: entry.hasDueDate ? entry.dueDate : null,
+          priority: entry.priority,
           status: 'pending'
         });
       }
@@ -712,6 +826,13 @@ export function SmartBudgetingView() {
       typeof detail.item.actualAmount === 'number' && !Number.isNaN(detail.item.actualAmount)
         ? detail.item.actualAmount
         : undefined;
+    const fallbackDate = formatISO(parseISO(detail.item.createdAt), { representation: 'date' });
+    const remainderSource =
+      typeof detail.item.remainderAmount === 'number' && !Number.isNaN(detail.item.remainderAmount)
+        ? detail.item.remainderAmount
+        : detail.remainder > 0
+        ? detail.remainder
+        : undefined;
     setEditDraft({
       categoryId: detail.item.categoryId,
       plannedAmount: String(detail.item.plannedAmount),
@@ -720,34 +841,73 @@ export function SmartBudgetingView() {
           ? String(manualActual)
           : detail.actual > 0
           ? String(detail.actual)
-          : ''
+          : '',
+      remainderAmount:
+        remainderSource !== undefined && remainderSource > 0 ? String(remainderSource) : '',
+      dueDate: detail.item.dueDate ?? fallbackDate,
+      hasDueDate: Boolean(detail.item.dueDate),
+      priority: detail.item.priority ?? 'medium'
     });
   };
 
   const handleCancelEdit = () => {
     setEditingItemId(null);
-    setEditDraft({ categoryId: '', plannedAmount: '', actualAmount: '' });
+    setEditDraft({
+      categoryId: '',
+      plannedAmount: '',
+      actualAmount: '',
+      remainderAmount: '',
+      dueDate: '',
+      hasDueDate: true,
+      priority: 'medium'
+    });
   };
 
   const handleSaveEdit = async (detail: PlannedExpenseDetail) => {
     const plannedValue = Number(editDraft.plannedAmount);
     const trimmedActual = editDraft.actualAmount.trim();
     const actualValue = trimmedActual === '' ? undefined : Number(trimmedActual);
+    const trimmedRemainder = editDraft.remainderAmount.trim();
+    const remainderValue = trimmedRemainder === '' ? null : Number(trimmedRemainder);
+    const requiresDueDate = editDraft.hasDueDate && editDraft.dueDate.trim() === '';
     if (!editDraft.categoryId || Number.isNaN(plannedValue) || plannedValue < 0) {
       return;
     }
     if (actualValue !== undefined && (Number.isNaN(actualValue) || actualValue < 0)) {
       return;
     }
+    if (remainderValue !== null && (Number.isNaN(remainderValue) || remainderValue < 0 || remainderValue > plannedValue)) {
+      return;
+    }
+    if (requiresDueDate) {
+      return;
+    }
     setSavingItemId(detail.item.id);
     try {
+      let nextActualValue = actualValue;
+      if (remainderValue !== null) {
+        nextActualValue = Math.max(plannedValue - remainderValue, 0);
+      }
       await updatePlannedExpense(detail.item.id, {
         categoryId: editDraft.categoryId,
         plannedAmount: plannedValue,
-        actualAmount: actualValue
+        actualAmount: nextActualValue,
+        remainderAmount: remainderValue,
+        priority: editDraft.priority,
+        dueDate: editDraft.hasDueDate
+          ? editDraft.dueDate || detail.item.dueDate || formatISO(new Date(), { representation: 'date' })
+          : null
       });
       setEditingItemId(null);
-      setEditDraft({ categoryId: '', plannedAmount: '', actualAmount: '' });
+      setEditDraft({
+        categoryId: '',
+        plannedAmount: '',
+        actualAmount: '',
+        remainderAmount: '',
+        dueDate: '',
+        hasDueDate: true,
+        priority: 'medium'
+      });
     } finally {
       setSavingItemId(null);
     }
@@ -825,6 +985,7 @@ export function SmartBudgetingView() {
   const handleFocusDetail = (detail: PlannedExpenseDetail) => {
     setNavigatorFilter('all');
     setCategorySearchTerm('');
+    setNavigatorView('category');
     focusCategory(detail.item.categoryId, true);
     handleStartEdit(detail);
   };
@@ -836,10 +997,12 @@ export function SmartBudgetingView() {
       categoryLookup.get(detail.item.categoryId)?.name ??
       categories.find((cat) => cat.id === detail.item.categoryId)?.name ??
       'Uncategorised';
-    const dueDateLabel = new Date(detail.item.dueDate).toLocaleDateString('en-IN', {
-      month: 'short',
-      day: 'numeric'
-    });
+    const dueDateLabel = detail.item.dueDate
+      ? new Date(detail.item.dueDate).toLocaleDateString('en-IN', {
+          month: 'short',
+          day: 'numeric'
+        })
+      : 'No due date';
     const progressPercentRaw =
       detail.item.plannedAmount <= 0
         ? detail.actual > 0
@@ -849,9 +1012,8 @@ export function SmartBudgetingView() {
     const progressPercent = Number.isFinite(progressPercentRaw) ? progressPercentRaw : 0;
     const progressWidth = Math.max(0, Math.min(100, progressPercent));
     const progressColor = progressColorByStatus[detail.status];
-    const varianceLabel = detail.variance >= 0 ? 'Saved' : 'Overspent';
-    const varianceDisplay = Math.abs(detail.variance);
     const statusToken = spendingBadgeStyles[detail.status];
+    const priorityToken = PRIORITY_TOKEN_STYLES[detail.priority ?? 'medium'];
     const actualToneClass = statusToken.toneClass;
     const actualBackgroundClass =
       detail.status === 'over'
@@ -859,18 +1021,38 @@ export function SmartBudgetingView() {
         : detail.status === 'under'
         ? 'bg-success/10'
         : 'bg-slate-950/80';
+    const remainderValue = detail.remainder;
+    const remainderLabel = remainderValue >= 0 ? 'Remaining' : 'Overspent';
+    const remainderDisplay = Math.abs(remainderValue);
+    const remainderToneClass = remainderValue >= 0 ? 'text-success' : 'text-danger';
+    const remainderBackgroundClass = remainderValue >= 0 ? 'bg-success/10' : 'bg-danger/10';
     const isCurrentCategoryMissing =
       isEditing && editDraft.categoryId && !categoryOptions.some((option) => option.id === editDraft.categoryId);
     const parsedPlanned = Number(editDraft.plannedAmount);
     const parsedActual = editDraft.actualAmount.trim() === '' ? undefined : Number(editDraft.actualAmount);
+    const parsedRemainder = editDraft.remainderAmount.trim() === '' ? null : Number(editDraft.remainderAmount);
+    const isRemainderProvided = editDraft.remainderAmount.trim() !== '';
     const hasPlannedError = isEditing && (Number.isNaN(parsedPlanned) || parsedPlanned < 0);
-    const hasActualError = isEditing && parsedActual !== undefined && (Number.isNaN(parsedActual) || parsedActual < 0);
+    const hasActualError =
+      isEditing &&
+      !isRemainderProvided &&
+      parsedActual !== undefined &&
+      (Number.isNaN(parsedActual) || parsedActual < 0);
+    const hasRemainderError =
+      isEditing &&
+      parsedRemainder !== null &&
+      (Number.isNaN(parsedRemainder) ||
+        parsedRemainder < 0 ||
+        (Number.isFinite(parsedPlanned) && parsedPlanned >= 0 && parsedRemainder > parsedPlanned));
+    const requiresDueDate = isEditing && editDraft.hasDueDate && editDraft.dueDate.trim() === '';
     const isSaveDisabled =
       !isEditing ||
       !editDraft.categoryId ||
       editDraft.plannedAmount.trim() === '' ||
       hasPlannedError ||
       hasActualError ||
+      hasRemainderError ||
+      requiresDueDate ||
       isSaving;
 
     return (
@@ -882,9 +1064,14 @@ export function SmartBudgetingView() {
         <header className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div>
             <h4 className="text-base font-semibold text-slate-100">{detail.item.name}</h4>
-            <p className="mt-1 flex items-center gap-2 text-xs text-slate-500">
-              {dueDateLabel}
+            <p className="mt-1 flex flex-wrap items-center gap-2 text-xs text-slate-500">
+              <span>{dueDateLabel}</span>
               {statusBadge(detail.item.status)}
+              <span
+                className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${priorityToken.badgeClass}`}
+              >
+                {priorityToken.label}
+              </span>
             </p>
           </div>
           <div className="flex flex-col items-end gap-1 text-xs">
@@ -895,7 +1082,7 @@ export function SmartBudgetingView() {
           </div>
         </header>
 
-        <div className="mt-3 grid gap-3 sm:grid-cols-2">
+        <div className="mt-3 grid gap-3 sm:grid-cols-3">
           <div className="rounded-lg border border-slate-800 bg-slate-950/80 p-3">
             <p className="text-[11px] uppercase text-slate-500">Planned</p>
             <p className="text-sm font-semibold text-warning">{formatCurrency(detail.item.plannedAmount)}</p>
@@ -904,14 +1091,25 @@ export function SmartBudgetingView() {
             <p className="text-[11px] uppercase text-slate-500">Spent</p>
             <p className={`text-sm font-semibold ${actualToneClass}`}>{formatCurrency(detail.actual)}</p>
           </div>
+          <div className={`rounded-lg border border-slate-800 p-3 ${remainderBackgroundClass}`}>
+            <p className="text-[11px] uppercase text-slate-500">Remainder</p>
+            <p className={`text-sm font-semibold ${remainderToneClass}`}>
+              {formatCurrency(remainderDisplay)}
+            </p>
+            <p className="text-[10px] text-slate-400">{remainderLabel}</p>
+          </div>
         </div>
 
         <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px]">
           <span className={`rounded-full px-2 py-0.5 font-semibold ${statusToken.badgeClass}`}>
             {statusToken.label}
           </span>
-          <span className={`rounded-full px-2 py-0.5 font-semibold ${detail.variance >= 0 ? 'bg-success/20 text-success' : 'bg-danger/20 text-danger'}`}>
-            {varianceLabel} {formatCurrency(varianceDisplay)}
+          <span
+            className={`rounded-full px-2 py-0.5 font-semibold ${
+              remainderValue >= 0 ? 'bg-success/20 text-success' : 'bg-danger/20 text-danger'
+            }`}
+          >
+            {remainderLabel} {formatCurrency(remainderDisplay)}
           </span>
           <span className="rounded-full bg-slate-800 px-2 py-0.5 font-semibold text-slate-300">{categoryName}</span>
         </div>
@@ -936,13 +1134,14 @@ export function SmartBudgetingView() {
 
         {isEditing && (
           <div className="mt-4 space-y-3 rounded-lg border border-slate-800 bg-slate-950/80 p-3">
-            <div className="grid gap-3 sm:grid-cols-3">
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
               <div>
                 <label className="text-[11px] uppercase text-slate-500">Category</label>
                 <select
                   className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm"
                   value={editDraft.categoryId}
                   onChange={(event) => setEditDraft((prev) => ({ ...prev, categoryId: event.target.value }))}
+                  disabled={isSaving}
                 >
                   {isCurrentCategoryMissing && (
                     <option value={detail.item.categoryId}>
@@ -955,6 +1154,11 @@ export function SmartBudgetingView() {
                     </option>
                   ))}
                 </select>
+                {isCurrentCategoryMissing && (
+                  <p className="mt-1 text-[10px] text-warning">
+                    The original category is no longer available. Pick another one before saving.
+                  </p>
+                )}
               </div>
               <div>
                 <label className="text-[11px] uppercase text-slate-500">Planned (₹)</label>
@@ -964,6 +1168,7 @@ export function SmartBudgetingView() {
                   className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm"
                   value={editDraft.plannedAmount}
                   onChange={(event) => setEditDraft((prev) => ({ ...prev, plannedAmount: event.target.value }))}
+                  disabled={isSaving}
                 />
                 {hasPlannedError && <p className="mt-1 text-[10px] text-danger">Enter a valid planned amount.</p>}
               </div>
@@ -973,11 +1178,81 @@ export function SmartBudgetingView() {
                   type="number"
                   min={0}
                   placeholder="Auto from transactions"
-                  className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm"
+                  className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm disabled:opacity-60"
                   value={editDraft.actualAmount}
                   onChange={(event) => setEditDraft((prev) => ({ ...prev, actualAmount: event.target.value }))}
+                  disabled={isRemainderProvided || isSaving}
                 />
                 {hasActualError && <p className="mt-1 text-[10px] text-danger">Enter a valid spent amount.</p>}
+                {isRemainderProvided && (
+                  <p className="mt-1 text-[10px] text-slate-500">Remainder will override this value when you save.</p>
+                )}
+              </div>
+              <div>
+                <label className="text-[11px] uppercase text-slate-500">Remainder (₹)</label>
+                <input
+                  type="number"
+                  min={0}
+                  className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm"
+                  value={editDraft.remainderAmount}
+                  onChange={(event) => setEditDraft((prev) => ({ ...prev, remainderAmount: event.target.value }))}
+                  disabled={isSaving}
+                />
+                {hasRemainderError && (
+                  <p className="mt-1 text-[10px] text-danger">Enter a remainder between 0 and the planned amount.</p>
+                )}
+                <p className="mt-1 text-[10px] text-slate-500">
+                  Leave blank to use matched spend. Fill this to automatically set the spent amount.
+                </p>
+              </div>
+              <div>
+                <label className="text-[11px] uppercase text-slate-500">Due date</label>
+                <input
+                  type="date"
+                  className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm disabled:opacity-60"
+                  value={editDraft.dueDate}
+                  onChange={(event) => setEditDraft((prev) => ({ ...prev, dueDate: event.target.value }))}
+                  disabled={!editDraft.hasDueDate || isSaving}
+                />
+                <label className="mt-2 flex items-center gap-2 text-[11px] text-slate-400">
+                  <input
+                    type="checkbox"
+                    checked={!editDraft.hasDueDate}
+                    onChange={(event) => {
+                      const noDueDate = event.target.checked;
+                      setEditDraft((prev) => ({
+                        ...prev,
+                        hasDueDate: !noDueDate,
+                        dueDate: noDueDate ? prev.dueDate : prev.dueDate || resolveDefaultDueDate()
+                      }));
+                    }}
+                    disabled={isSaving}
+                  />
+                  <span>No due date</span>
+                </label>
+                {requiresDueDate && (
+                  <p className="mt-1 text-[10px] text-danger">Choose a due date or mark it as no due date.</p>
+                )}
+              </div>
+              <div>
+                <label className="text-[11px] uppercase text-slate-500">Priority</label>
+                <select
+                  className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm"
+                  value={editDraft.priority}
+                  onChange={(event) =>
+                    setEditDraft((prev) => ({
+                      ...prev,
+                      priority: event.target.value as PlannedExpenseItem['priority']
+                    }))
+                  }
+                  disabled={isSaving}
+                >
+                  {PRIORITY_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
               </div>
             </div>
             <div className="flex flex-wrap gap-2">
@@ -999,7 +1274,8 @@ export function SmartBudgetingView() {
               </button>
             </div>
             <p className="text-[11px] text-slate-500">
-              Leave the spent field blank to keep using the automatically matched transactions.
+              Leave the spent field blank to keep using automatically matched transactions. Use the remainder field to
+              capture leftover budget.
             </p>
           </div>
         )}
@@ -1052,31 +1328,34 @@ export function SmartBudgetingView() {
       planned: 0,
       actual: 0,
       variance: 0,
-      itemCount: 0
+      itemCount: 0,
+      remainder: 0
     };
     const directItems = itemsByCategory.get(category.id) ?? [];
     const categoryStatus: PlannedExpenseSpendingHealth =
       summary.actual === 0 ? 'not-spent' : summary.variance >= 0 ? 'under' : 'over';
     const statusToken = spendingBadgeStyles[categoryStatus];
     const descendantIds = expenseDescendantsMap.get(category.id) ?? new Set<string>([category.id]);
-    const remainderClass = summary.variance >= 0 ? 'text-success' : 'text-danger';
-    const remainderLabel = summary.variance >= 0 ? 'Remaining' : 'Overspent';
-    const remainderDescriptor = summary.actual === 0 ? 'Awaiting spend' : remainderLabel;
+    const remainderValue = summary.remainder;
+    const remainderClass = remainderValue >= 0 ? 'text-success' : 'text-danger';
+    const remainderLabel = remainderValue >= 0 ? 'Remaining' : 'Overspent';
+    const remainderDescriptor = summary.actual === 0 && remainderValue >= 0 ? 'Awaiting spend' : remainderLabel;
     const nextDueDetail = plannedExpenseDetails.reduce<PlannedExpenseDetail | null>((closest, detail) => {
-      if (!descendantIds.has(detail.item.categoryId)) {
+      if (!descendantIds.has(detail.item.categoryId) || !detail.item.dueDate) {
         return closest;
       }
-      if (!closest) return detail;
+      if (!closest || !closest.item.dueDate) return detail;
       const currentTime = new Date(detail.item.dueDate).getTime();
       const closestTime = new Date(closest.item.dueDate).getTime();
       return currentTime < closestTime ? detail : closest;
     }, null);
-    const nextDueLabel = nextDueDetail
-      ? new Date(nextDueDetail.item.dueDate).toLocaleDateString('en-IN', {
-          month: 'short',
-          day: 'numeric'
-        })
-      : null;
+    const nextDueLabel =
+      nextDueDetail && nextDueDetail.item.dueDate
+        ? new Date(nextDueDetail.item.dueDate).toLocaleDateString('en-IN', {
+            month: 'short',
+            day: 'numeric'
+          })
+        : null;
     const matchesCategorySearch =
       normalisedSearchTerm !== '' && category.name.toLowerCase().includes(normalisedSearchTerm);
     const visibleDirectItems = directItems.filter((detail) => {
@@ -1162,7 +1441,7 @@ export function SmartBudgetingView() {
             {formatCurrency(summary.actual)}
           </div>
           <div className={`text-right text-sm font-semibold ${remainderClass}`}>
-            <div>{formatCurrency(summary.variance)}</div>
+            <div>{formatCurrency(summary.remainder)}</div>
             <span className="block text-[10px] font-semibold text-slate-400">{remainderDescriptor}</span>
           </div>
         </div>
@@ -1183,7 +1462,10 @@ export function SmartBudgetingView() {
   const renderedCategorySections = expenseCategoryTree
     .map((category) => renderCategorySection(category))
     .filter((section): section is JSX.Element => section !== null);
-  const hasNavigatorResults = renderedCategorySections.length > 0 || visibleUncategorisedDetails.length > 0;
+  const hasNavigatorResults =
+    navigatorView === 'priority'
+      ? filteredPriorityDetails.length > 0
+      : renderedCategorySections.length > 0 || visibleUncategorisedDetails.length > 0;
   const inspectorBreadcrumb = (() => {
     if (!focusedCategoryId) return '';
     const names: string[] = [];
@@ -1232,6 +1514,7 @@ export function SmartBudgetingView() {
                       <th className="px-3 py-2 font-semibold">Name</th>
                       <th className="px-3 py-2 font-semibold">Amount (₹)</th>
                       <th className="px-3 py-2 font-semibold">Due date</th>
+                      <th className="px-3 py-2 font-semibold">Priority</th>
                       <th className="px-3 py-2 font-semibold">Category</th>
                       <th className="px-3 py-2 font-semibold">Actions</th>
                     </tr>
@@ -1260,12 +1543,50 @@ export function SmartBudgetingView() {
                             />
                           </td>
                           <td className="px-3 py-2">
-                            <input
-                              type="date"
+                            <div className="flex flex-col gap-2">
+                              <input
+                                type="date"
+                                className="w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm disabled:opacity-60"
+                                value={entry.dueDate}
+                                onChange={(event) =>
+                                  handleEntryChange(entry.id, { dueDate: event.target.value })
+                                }
+                                disabled={!entry.hasDueDate}
+                              />
+                              <label className="flex items-center gap-2 text-xs text-slate-400">
+                                <input
+                                  type="checkbox"
+                                  checked={!entry.hasDueDate}
+                                  onChange={(event) => {
+                                    const noDueDate = event.target.checked;
+                                    handleEntryChange(entry.id, {
+                                      hasDueDate: !noDueDate,
+                                      ...(noDueDate
+                                        ? {}
+                                        : { dueDate: entry.dueDate || resolveDefaultDueDate() })
+                                    });
+                                  }}
+                                />
+                                <span>No due date</span>
+                              </label>
+                            </div>
+                          </td>
+                          <td className="px-3 py-2">
+                            <select
                               className="w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm"
-                              value={entry.dueDate}
-                              onChange={(event) => handleEntryChange(entry.id, { dueDate: event.target.value })}
-                            />
+                              value={entry.priority}
+                              onChange={(event) =>
+                                handleEntryChange(entry.id, {
+                                  priority: event.target.value as PlannedExpenseItem['priority']
+                                })
+                              }
+                            >
+                              {PRIORITY_OPTIONS.map((option) => (
+                                <option key={option.value} value={option.value}>
+                                  {option.label}
+                                </option>
+                              ))}
+                            </select>
                           </td>
                           <td className="px-3 py-2">
                             <div className="flex flex-col gap-2">
@@ -1592,6 +1913,25 @@ export function SmartBudgetingView() {
 
         <div className="mt-4 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
           <div className="flex flex-wrap items-center gap-2 text-xs">
+            {navigatorViewOptions.map(({ key, label }) => {
+              const isActive = navigatorView === key;
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  onClick={() => setNavigatorView(key)}
+                  className={`rounded-full border px-3 py-1 font-semibold transition ${
+                    isActive
+                      ? 'border-accent bg-accent text-slate-900'
+                      : 'border-slate-700 text-slate-300 hover:border-accent hover:text-accent'
+                  }`}
+                >
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+          <div className="flex flex-wrap items-center gap-2 text-xs">
             {navigatorFilterOptions.map(({ key, label }) => {
               const isActive = navigatorFilter === key;
               return (
@@ -1629,20 +1969,24 @@ export function SmartBudgetingView() {
                 </button>
               )}
             </div>
-            <button
-              type="button"
-              onClick={expandAllCategories}
-              className="rounded-lg border border-slate-700 px-3 py-2 font-semibold text-slate-300 transition hover:border-accent hover:text-accent"
-            >
-              Expand all
-            </button>
-            <button
-              type="button"
-              onClick={collapseAllCategories}
-              className="rounded-lg border border-slate-700 px-3 py-2 font-semibold text-slate-300 transition hover:border-accent hover:text-accent"
-            >
-              Collapse all
-            </button>
+            {navigatorView === 'category' && (
+              <>
+                <button
+                  type="button"
+                  onClick={expandAllCategories}
+                  className="rounded-lg border border-slate-700 px-3 py-2 font-semibold text-slate-300 transition hover:border-accent hover:text-accent"
+                >
+                  Expand all
+                </button>
+                <button
+                  type="button"
+                  onClick={collapseAllCategories}
+                  className="rounded-lg border border-slate-700 px-3 py-2 font-semibold text-slate-300 transition hover:border-accent hover:text-accent"
+                >
+                  Collapse all
+                </button>
+              </>
+            )}
           </div>
         </div>
 
@@ -1671,34 +2015,70 @@ export function SmartBudgetingView() {
 
         <div className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,3fr)_minmax(260px,1fr)]">
           <div className="space-y-4">
-            {renderedCategorySections.length > 0 && (
-              <div className="overflow-hidden rounded-xl border border-slate-800 bg-slate-950/70">
-                <div className="grid grid-cols-[minmax(0,3fr)_minmax(140px,1fr)_minmax(140px,1fr)_minmax(160px,1fr)] items-center gap-4 border-b border-slate-800/80 bg-slate-950 px-4 py-3 text-[11px] font-semibold uppercase tracking-wide text-slate-400">
-                  <span>Category</span>
-                  <span className="text-right">Planned</span>
-                  <span className="text-right">Spent</span>
-                  <span className="text-right">Remainder</span>
-                </div>
-                <div>{renderedCategorySections}</div>
-              </div>
-            )}
-            {visibleUncategorisedDetails.length > 0 && (
-              <div className="rounded-xl border border-slate-800 bg-slate-950/70 p-4">
-                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                  <div>
-                    <h4 className="text-sm font-semibold text-slate-100">Uncategorised items</h4>
-                    <p className="text-[11px] text-slate-500">
-                      Assign a category so these expenses roll into the right budgets.
-                    </p>
+            {navigatorView === 'category' ? (
+              <>
+                {renderedCategorySections.length > 0 && (
+                  <div className="overflow-hidden rounded-xl border border-slate-800 bg-slate-950/70">
+                    <div className="grid grid-cols-[minmax(0,3fr)_minmax(140px,1fr)_minmax(140px,1fr)_minmax(160px,1fr)] items-center gap-4 border-b border-slate-800/80 bg-slate-950 px-4 py-3 text-[11px] font-semibold uppercase tracking-wide text-slate-400">
+                      <span>Category</span>
+                      <span className="text-right">Planned</span>
+                      <span className="text-right">Spent</span>
+                      <span className="text-right">Remainder</span>
+                    </div>
+                    <div>{renderedCategorySections}</div>
                   </div>
-                  <span className="rounded-full bg-warning/20 px-2 py-0.5 text-[10px] font-semibold text-warning">
-                    {visibleUncategorisedDetails.length} item{visibleUncategorisedDetails.length === 1 ? '' : 's'}
-                  </span>
-                </div>
-                <div className="mt-3 space-y-3">
-                  {visibleUncategorisedDetails.map((detail) => renderItemCard(detail, 0))}
-                </div>
-              </div>
+                )}
+                {visibleUncategorisedDetails.length > 0 && (
+                  <div className="rounded-xl border border-slate-800 bg-slate-950/70 p-4">
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                      <div>
+                        <h4 className="text-sm font-semibold text-slate-100">Uncategorised items</h4>
+                        <p className="text-[11px] text-slate-500">
+                          Assign a category so these expenses roll into the right budgets.
+                        </p>
+                      </div>
+                      <span className="rounded-full bg-warning/20 px-2 py-0.5 text-[10px] font-semibold text-warning">
+                        {visibleUncategorisedDetails.length} item{visibleUncategorisedDetails.length === 1 ? '' : 's'}
+                      </span>
+                    </div>
+                    <div className="mt-3 space-y-3">
+                      {visibleUncategorisedDetails.map((detail) => renderItemCard(detail, 0))}
+                    </div>
+                  </div>
+                )}
+              </>
+            ) : (
+              <>
+                {PRIORITY_ORDER.map((priority) => {
+                  const items = priorityGroups[priority];
+                  if (items.length === 0) {
+                    return null;
+                  }
+                  const token = PRIORITY_TOKEN_STYLES[priority];
+                  return (
+                    <section
+                      key={priority}
+                      className="rounded-xl border border-slate-800 bg-slate-950/70 p-4"
+                    >
+                      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                        <div className="flex items-center gap-2">
+                          <span
+                            className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${token.badgeClass}`}
+                          >
+                            {token.label}
+                          </span>
+                          <span className="text-xs text-slate-500">
+                            {items.length} item{items.length === 1 ? '' : 's'}
+                          </span>
+                        </div>
+                      </div>
+                      <div className="mt-3 space-y-3">
+                        {items.map((detail) => renderItemCard(detail, 0))}
+                      </div>
+                    </section>
+                  );
+                })}
+              </>
             )}
             {!hasNavigatorResults && (
               <p className="text-sm text-slate-500">
@@ -1726,7 +2106,7 @@ export function SmartBudgetingView() {
             </div>
             {inspectorCategory ? (
               <>
-                <div className="grid gap-3 text-[11px] sm:grid-cols-2">
+                <div className="grid gap-3 text-[11px] sm:grid-cols-3">
                   <div className="rounded-lg border border-slate-800 bg-slate-950/80 p-3">
                     <p className="uppercase text-slate-500">Planned</p>
                     <p className="text-sm font-semibold text-warning">
@@ -1739,7 +2119,14 @@ export function SmartBudgetingView() {
                       {formatCurrency(inspectorSummary?.actual ?? 0)}
                     </p>
                   </div>
-                  <div className="rounded-lg border border-slate-800 bg-slate-950/80 p-3 sm:col-span-2">
+                  <div className="rounded-lg border border-slate-800 bg-slate-950/80 p-3">
+                    <p className="uppercase text-slate-500">Remainder</p>
+                    <p className={`text-sm font-semibold ${inspectorRemainderClass}`}>
+                      {formatCurrency(Math.abs(inspectorRemainderValue))}
+                    </p>
+                    <p className="text-[10px] text-slate-400">{inspectorRemainderLabel}</p>
+                  </div>
+                  <div className="rounded-lg border border-slate-800 bg-slate-950/80 p-3 sm:col-span-3">
                     <label className="text-[11px] uppercase text-slate-500">
                       {viewMode === 'monthly' ? 'Monthly budget baseline' : 'Yearly budget baseline'}
                     </label>
@@ -1840,10 +2227,12 @@ export function SmartBudgetingView() {
                           <div className="flex items-center justify-between gap-2">
                             <span className="font-semibold text-slate-100">{detail.item.name}</span>
                             <span>
-                              {new Date(detail.item.dueDate).toLocaleDateString('en-IN', {
-                                month: 'short',
-                                day: 'numeric'
-                              })}
+                              {detail.item.dueDate
+                                ? new Date(detail.item.dueDate).toLocaleDateString('en-IN', {
+                                    month: 'short',
+                                    day: 'numeric'
+                                  })
+                                : 'No due date'}
                             </span>
                           </div>
                           <div className="mt-1 flex items-center justify-between gap-2">


### PR DESCRIPTION
## Summary
- extend planned expense typing and persistence to include optional due dates, manual remainder overrides, and priority levels
- overhaul the smart budgeting view with priority-based navigation, remainder metrics, and flexible due-date editing
- align supporting views and insight engines with the new planned expense behaviour

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2011c2aa4832cb31cb3d7c238b0dd