### PR TITLE
Refactor dashboard into atomic component architecture

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,23 +1,35 @@
 import { useEffect, useState } from 'react';
-import { NavLink, Route, Routes, useLocation } from 'react-router-dom';
-import { DashboardView } from './views/DashboardView';
-import { BalanceSheetView } from './views/BalanceSheetView';
-import { TrendAnalysisView } from './views/TrendAnalysisView';
-import { SmartBudgetingView } from './views/SmartBudgetingView';
-import { IncomeManagementView } from './views/IncomeManagementView';
-import { RecurringExpensesView } from './views/RecurringExpensesView';
-import { GoalSimulatorView } from './views/GoalSimulatorView';
-import { InsightsView } from './views/InsightsView';
-import { WealthAcceleratorView } from './views/WealthAcceleratorView';
-import { OfflineSyncStatus } from './components/OfflineSyncStatus';
+import { Route, Routes, useLocation } from 'react-router-dom';
+import { Button } from './components/atoms/Button';
 import { InitialSetupDialog } from './components/InitialSetupDialog';
+import { OfflineSyncStatus } from './components/OfflineSyncStatus';
 import { QuickExpenseCapture } from './components/QuickExpenseCapture';
+import { NavItem } from './components/molecules/NavItem';
+import { AppHeader } from './components/organisms/AppHeader/AppHeader';
+import { AppNavigation } from './components/organisms/AppNavigation/AppNavigation';
+import { AppShell } from './components/organisms/AppShell/AppShell';
+import { BalanceSheetView } from './views/BalanceSheetView';
+import { DashboardView } from './views/DashboardView';
+import { GoalSimulatorView } from './views/GoalSimulatorView';
+import { IncomeManagementView } from './views/IncomeManagementView';
+import { InsightsView } from './views/InsightsView';
+import { RecurringExpensesView } from './views/RecurringExpensesView';
+import { SmartBudgetingView } from './views/SmartBudgetingView';
+import { TrendAnalysisView } from './views/TrendAnalysisView';
+import { WealthAcceleratorView } from './views/WealthAcceleratorView';
 import { useFinancialStore } from './store/FinancialStoreProvider';
 
-const navLinkClass = ({ isActive }: { isActive: boolean }) =>
-  `px-4 py-2 rounded-md text-sm font-medium transition-colors duration-200 ${
-    isActive ? 'bg-accent text-slate-900' : 'bg-slate-800 hover:bg-slate-700'
-  }`;
+const NAV_LINKS = [
+  { to: '/', label: 'CEO Dashboard', end: true },
+  { to: '/balance', label: 'Unified Balance Sheet' },
+  { to: '/trends', label: 'Trend Analysis' },
+  { to: '/budgeting', label: 'Smart Budgeting' },
+  { to: '/income', label: 'Income & Categories' },
+  { to: '/recurring', label: 'Recurring Expenses Hub' },
+  { to: '/goals', label: 'Goal Setting & Simulation' },
+  { to: '/insights', label: 'Actionable Insights' },
+  { to: '/accelerator', label: 'Wealth Accelerator Intelligence' }
+] as const;
 
 export default function App() {
   const [isNavOpen, setIsNavOpen] = useState(false);
@@ -28,93 +40,59 @@ export default function App() {
     setIsNavOpen(false);
   }, [location.pathname]);
 
-  return (
-    <div className="relative min-h-screen bg-slate-950 text-slate-100">
-      <header className="border-b border-slate-800 bg-slate-900/60 backdrop-blur">
-        <div className="mx-auto flex max-w-7xl flex-col gap-4 px-4 py-6 sm:px-6 md:flex-row md:items-center md:justify-between">
-          <div className="flex w-full flex-col gap-4 md:flex-row md:items-center md:gap-6">
-            <div className="space-y-1">
-              <h1 className="text-3xl font-semibold text-accent">Wealth Accelerator</h1>
-              <p className="text-sm text-slate-400">
-                Offline-first financial intelligence engine for Indian CEOs & households
-              </p>
-            </div>
-            <button
-              type="button"
-              onClick={() => setIsNavOpen((open) => !open)}
-              className="inline-flex items-center justify-center gap-2 self-start rounded-lg border border-slate-700 px-3 py-2 text-sm font-semibold md:hidden"
-              aria-expanded={isNavOpen}
-              aria-controls="primary-navigation"
-            >
-              <span aria-hidden className="text-lg leading-none">☰</span>
-              Menu
-            </button>
-          </div>
-          <div className="flex flex-col items-stretch gap-2 md:min-w-[260px]">
-            <OfflineSyncStatus />
-            {!isInitialised && hasDismissedInitialSetup ? (
-              <button
-                type="button"
-                onClick={requestInitialSetup}
-                className="rounded-lg border border-accent/50 px-3 py-2 text-xs font-semibold text-accent transition hover:bg-accent/10"
-              >
-                Resume ledger setup
-              </button>
-            ) : null}
-          </div>
-        </div>
-      </header>
-      <div className="mx-auto flex max-w-7xl flex-col gap-6 px-4 py-8 sm:px-6 md:flex-row">
-        <nav
-          id="primary-navigation"
-          className={`flex flex-col gap-2 overflow-hidden rounded-2xl border border-slate-800 bg-slate-900/70 p-4 shadow transition-all md:max-w-xs md:border-0 md:bg-transparent md:p-0 md:shadow-none ${
-            isNavOpen ? 'max-h-[32rem] opacity-100' : 'max-h-0 opacity-0 md:max-h-full md:opacity-100'
-          } md:flex`}
+  const headerRightSlot = (
+    <>
+      <OfflineSyncStatus />
+      {!isInitialised && hasDismissedInitialSetup ? (
+        <Button
+          type="button"
+          onClick={requestInitialSetup}
+          variant="secondary"
+          className="border-accent/50 text-xs font-semibold text-accent hover:bg-accent/10"
         >
-          <NavLink to="/" end className={navLinkClass}>
-            CEO Dashboard
-          </NavLink>
-          <NavLink to="/balance" className={navLinkClass}>
-            Unified Balance Sheet
-          </NavLink>
-          <NavLink to="/trends" className={navLinkClass}>
-            Trend Analysis
-          </NavLink>
-          <NavLink to="/budgeting" className={navLinkClass}>
-            Smart Budgeting
-          </NavLink>
-          <NavLink to="/income" className={navLinkClass}>
-            Income & Categories
-          </NavLink>
-          <NavLink to="/recurring" className={navLinkClass}>
-            Recurring Expenses Hub
-          </NavLink>
-          <NavLink to="/goals" className={navLinkClass}>
-            Goal Setting & Simulation
-          </NavLink>
-          <NavLink to="/insights" className={navLinkClass}>
-            Actionable Insights
-          </NavLink>
-          <NavLink to="/accelerator" className={navLinkClass}>
-            Wealth Accelerator Intelligence
-          </NavLink>
-        </nav>
-        <main className="flex-1 rounded-2xl border border-slate-800 bg-slate-900/60 p-4 shadow-lg sm:p-6">
-          <Routes>
-            <Route path="/" element={<DashboardView />} />
-            <Route path="/balance" element={<BalanceSheetView />} />
-            <Route path="/trends" element={<TrendAnalysisView />} />
-            <Route path="/budgeting" element={<SmartBudgetingView />} />
-            <Route path="/income" element={<IncomeManagementView />} />
-            <Route path="/recurring" element={<RecurringExpensesView />} />
-            <Route path="/goals" element={<GoalSimulatorView />} />
-            <Route path="/insights" element={<InsightsView />} />
-            <Route path="/accelerator" element={<WealthAcceleratorView />} />
-          </Routes>
-        </main>
-      </div>
-      <QuickExpenseCapture />
-      <InitialSetupDialog />
-    </div>
+          Resume ledger setup
+        </Button>
+      ) : null}
+    </>
+  );
+
+  return (
+    <AppShell
+      header={
+        <AppHeader
+          title="Wealth Accelerator"
+          subtitle="Offline-first financial intelligence engine for Indian CEOs & households"
+          isNavOpen={isNavOpen}
+          onToggleNav={() => setIsNavOpen((open) => !open)}
+          rightSlot={headerRightSlot}
+        />
+      }
+      navigation={
+        <AppNavigation
+          isNavOpen={isNavOpen}
+          items={NAV_LINKS.map((link) => (
+            <NavItem key={link.to} to={link.to} end={link.end} label={link.label} />
+          ))}
+        />
+      }
+      footer={
+        <>
+          <QuickExpenseCapture />
+          <InitialSetupDialog />
+        </>
+      }
+    >
+      <Routes>
+        <Route path="/" element={<DashboardView />} />
+        <Route path="/balance" element={<BalanceSheetView />} />
+        <Route path="/trends" element={<TrendAnalysisView />} />
+        <Route path="/budgeting" element={<SmartBudgetingView />} />
+        <Route path="/income" element={<IncomeManagementView />} />
+        <Route path="/recurring" element={<RecurringExpensesView />} />
+        <Route path="/goals" element={<GoalSimulatorView />} />
+        <Route path="/insights" element={<InsightsView />} />
+        <Route path="/accelerator" element={<WealthAcceleratorView />} />
+      </Routes>
+    </AppShell>
   );
 }

--- a/src/components/atoms/Button.tsx
+++ b/src/components/atoms/Button.tsx
@@ -1,0 +1,39 @@
+import { forwardRef } from 'react';
+import type { ButtonHTMLAttributes } from 'react';
+import { cn } from '../../utils/cn';
+
+type ButtonVariant = 'primary' | 'secondary' | 'ghost';
+
+type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: ButtonVariant;
+  isLoading?: boolean;
+};
+
+const variantStyles: Record<ButtonVariant, string> = {
+  primary:
+    'bg-accent text-slate-900 hover:bg-accent/90 focus-visible:outline-accent border border-accent/80',
+  secondary:
+    'bg-slate-800 text-slate-100 hover:bg-slate-700 focus-visible:outline-slate-400 border border-slate-700',
+  ghost: 'bg-transparent text-slate-300 hover:bg-slate-800 focus-visible:outline-slate-500 border border-transparent'
+};
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, children, variant = 'primary', isLoading, disabled, ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        className={cn(
+          'inline-flex items-center justify-center gap-2 rounded-lg px-4 py-2 text-sm font-semibold transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-60',
+          variantStyles[variant],
+          className
+        )}
+        disabled={disabled || isLoading}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  }
+);
+
+Button.displayName = 'Button';

--- a/src/components/atoms/Card.tsx
+++ b/src/components/atoms/Card.tsx
@@ -1,0 +1,11 @@
+import type { HTMLAttributes } from 'react';
+import { cn } from '../../utils/cn';
+
+export function Card({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('rounded-2xl border border-slate-800 bg-slate-900/60 shadow', className)}
+      {...props}
+    />
+  );
+}

--- a/src/components/atoms/SectionHeading.tsx
+++ b/src/components/atoms/SectionHeading.tsx
@@ -1,0 +1,6 @@
+import type { HTMLAttributes } from 'react';
+import { cn } from '../../utils/cn';
+
+export function SectionHeading({ className, ...props }: HTMLAttributes<HTMLHeadingElement>) {
+  return <h2 className={cn('text-lg font-semibold text-slate-100', className)} {...props} />;
+}

--- a/src/components/molecules/MetricHighlight.tsx
+++ b/src/components/molecules/MetricHighlight.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from 'react';
+import { Card } from '../atoms/Card';
+
+interface MetricHighlightProps {
+  title: string;
+  value: ReactNode;
+  subtitle?: ReactNode;
+}
+
+export function MetricHighlight({ title, value, subtitle }: MetricHighlightProps) {
+  return (
+    <Card className="p-5">
+      <p className="text-xs uppercase tracking-wide text-slate-400">{title}</p>
+      <p className="mt-2 text-2xl font-semibold text-slate-100">{value}</p>
+      {subtitle ? <p className="text-xs text-slate-500">{subtitle}</p> : null}
+    </Card>
+  );
+}

--- a/src/components/molecules/NavItem.tsx
+++ b/src/components/molecules/NavItem.tsx
@@ -1,0 +1,24 @@
+import { NavLink } from 'react-router-dom';
+import type { NavLinkProps } from 'react-router-dom';
+import { cn } from '../../utils/cn';
+
+type Props = NavLinkProps & {
+  label: string;
+};
+
+export function NavItem({ label, className, ...props }: Props) {
+  return (
+    <NavLink
+      {...props}
+      className={({ isActive }) =>
+        cn(
+          'px-4 py-2 text-sm font-medium transition-colors duration-200 rounded-md',
+          isActive ? 'bg-accent text-slate-900' : 'bg-slate-800 hover:bg-slate-700',
+          className
+        )
+      }
+    >
+      {label}
+    </NavLink>
+  );
+}

--- a/src/components/organisms/AppHeader/AppHeader.tsx
+++ b/src/components/organisms/AppHeader/AppHeader.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from 'react';
+import { Button } from '../../atoms/Button';
+
+interface AppHeaderProps {
+  title: string;
+  subtitle?: string;
+  isNavOpen: boolean;
+  onToggleNav: () => void;
+  rightSlot?: ReactNode;
+}
+
+export function AppHeader({ title, subtitle, isNavOpen, onToggleNav, rightSlot }: AppHeaderProps) {
+  return (
+    <header className="border-b border-slate-800 bg-slate-900/60 backdrop-blur">
+      <div className="mx-auto flex max-w-7xl flex-col gap-4 px-4 py-6 sm:px-6 md:flex-row md:items-center md:justify-between">
+        <div className="flex w-full flex-col gap-4 md:flex-row md:items-center md:gap-6">
+          <div className="space-y-1">
+            <h1 className="text-3xl font-semibold text-accent">{title}</h1>
+            {subtitle ? <p className="text-sm text-slate-400">{subtitle}</p> : null}
+          </div>
+          <Button
+            type="button"
+            onClick={onToggleNav}
+            className="md:hidden"
+            variant="secondary"
+            aria-expanded={isNavOpen}
+            aria-controls="primary-navigation"
+          >
+            <span aria-hidden className="text-lg leading-none">☰</span>
+            Menu
+          </Button>
+        </div>
+        {rightSlot ? <div className="flex flex-col items-stretch gap-2 md:min-w-[260px]">{rightSlot}</div> : null}
+      </div>
+    </header>
+  );
+}

--- a/src/components/organisms/AppNavigation/AppNavigation.tsx
+++ b/src/components/organisms/AppNavigation/AppNavigation.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from 'react';
+import { cn } from '../../../utils/cn';
+
+interface AppNavigationProps {
+  isNavOpen: boolean;
+  items: ReactNode;
+}
+
+export function AppNavigation({ isNavOpen, items }: AppNavigationProps) {
+  return (
+    <nav
+      id="primary-navigation"
+      className={cn(
+        'flex flex-col gap-2 overflow-hidden rounded-2xl border border-slate-800 bg-slate-900/70 p-4 shadow transition-all',
+        'md:max-w-xs md:border-0 md:bg-transparent md:p-0 md:shadow-none md:flex',
+        isNavOpen ? 'max-h-[32rem] opacity-100' : 'max-h-0 opacity-0 md:max-h-full md:opacity-100'
+      )}
+    >
+      {items}
+    </nav>
+  );
+}

--- a/src/components/organisms/AppShell/AppShell.tsx
+++ b/src/components/organisms/AppShell/AppShell.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react';
+
+interface AppShellProps {
+  header: ReactNode;
+  navigation: ReactNode;
+  children: ReactNode;
+  footer?: ReactNode;
+}
+
+export function AppShell({ header, navigation, children, footer }: AppShellProps) {
+  return (
+    <div className="relative min-h-screen bg-slate-950 text-slate-100">
+      {header}
+      <div className="mx-auto flex max-w-7xl flex-col gap-6 px-4 py-8 sm:px-6 md:flex-row">
+        {navigation}
+        <main className="flex-1 rounded-2xl border border-slate-800 bg-slate-900/60 p-4 shadow-lg sm:p-6">{children}</main>
+      </div>
+      {footer}
+    </div>
+  );
+}

--- a/src/components/organisms/RecentTransactionsTable.tsx
+++ b/src/components/organisms/RecentTransactionsTable.tsx
@@ -1,0 +1,55 @@
+import { format } from 'date-fns';
+import type { Transaction } from '../../types';
+import { Card } from '../atoms/Card';
+import { SectionHeading } from '../atoms/SectionHeading';
+
+interface RecentTransactionsTableProps {
+  transactions: Transaction[];
+  resolveCategoryName: (categoryId: string | undefined) => string;
+  formatCurrency: (value: number) => string;
+}
+
+export function RecentTransactionsTable({
+  transactions,
+  resolveCategoryName,
+  formatCurrency
+}: RecentTransactionsTableProps) {
+  return (
+    <section>
+      <SectionHeading className="mb-3">Recent Transactions</SectionHeading>
+      <Card className="border border-slate-800">
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-slate-800 text-sm">
+            <thead className="bg-slate-900/80 text-xs uppercase text-slate-400">
+              <tr>
+                <th className="px-4 py-3 text-left">Date</th>
+                <th className="px-4 py-3 text-left">Description</th>
+                <th className="px-4 py-3 text-left">Category</th>
+                <th className="px-4 py-3 text-right">Amount</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-800">
+              {transactions.map((txn) => (
+                <tr key={txn.id} className="hover:bg-slate-800/40">
+                  <td className="px-4 py-3">{format(new Date(txn.date), 'd MMM')}</td>
+                  <td className="px-4 py-3">{txn.description}</td>
+                  <td className="px-4 py-3">{resolveCategoryName(txn.categoryId)}</td>
+                  <td className={`px-4 py-3 text-right ${txn.amount < 0 ? 'text-danger' : 'text-success'}`}>
+                    {formatCurrency(txn.amount)}
+                  </td>
+                </tr>
+              ))}
+              {transactions.length === 0 ? (
+                <tr>
+                  <td colSpan={4} className="px-4 py-6 text-center text-sm text-slate-500">
+                    No transactions recorded yet.
+                  </td>
+                </tr>
+              ) : null}
+            </tbody>
+          </table>
+        </div>
+      </Card>
+    </section>
+  );
+}

--- a/src/components/organisms/SavingsGauge/SavingsCaptureDialog.tsx
+++ b/src/components/organisms/SavingsGauge/SavingsCaptureDialog.tsx
@@ -1,0 +1,149 @@
+import type { Account } from '../../../types';
+import { Button } from '../../atoms/Button';
+import { todayInputValue } from './useSavingsCapture';
+
+interface SavingsCaptureDialogProps {
+  isOpen: boolean;
+  form: {
+    label: string;
+    amount: string;
+    accountId: string;
+    date: string;
+    notes: string;
+  };
+  isSaving: boolean;
+  error: string | null;
+  assetAccounts: Account[];
+  onClose: () => void;
+  onSubmit: React.FormEventHandler<HTMLFormElement>;
+  onFormChange: (field: string, value: string) => void;
+}
+
+export function SavingsCaptureDialog({
+  isOpen,
+  form,
+  isSaving,
+  error,
+  assetAccounts,
+  onClose,
+  onSubmit,
+  onFormChange
+}: SavingsCaptureDialogProps) {
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-40 flex items-center justify-center bg-slate-950/80 p-4">
+      <div className="w-full max-w-lg rounded-2xl border border-slate-700 bg-slate-900/95 p-6 shadow-2xl">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h3 className="text-lg font-semibold text-emerald-300">Record a savings transfer</h3>
+            <p className="mt-1 text-sm text-slate-400">
+              Move surplus income into your asset accounts so the balance reflects in Total Net Worth.
+            </p>
+          </div>
+          <Button type="button" variant="ghost" className="p-1" onClick={onClose} aria-label="Close">
+            ✕
+          </Button>
+        </div>
+
+        <form onSubmit={onSubmit} className="mt-6 space-y-5">
+          <div>
+            <label className="block text-sm font-medium text-slate-200" htmlFor="savings-label">
+              Savings label
+            </label>
+            <input
+              id="savings-label"
+              type="text"
+              className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 shadow-inner focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
+              placeholder="e.g. Emergency fund top-up"
+              value={form.label}
+              onChange={(event) => onFormChange('label', event.target.value)}
+            />
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <label className="block text-sm font-medium text-slate-200" htmlFor="savings-amount">
+                Amount
+              </label>
+              <input
+                id="savings-amount"
+                type="number"
+                min="0"
+                step="0.01"
+                className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 shadow-inner focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
+                placeholder="50000"
+                value={form.amount}
+                onChange={(event) => onFormChange('amount', event.target.value)}
+                required
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-200" htmlFor="savings-date">
+                Transfer date
+              </label>
+              <input
+                id="savings-date"
+                type="date"
+                className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 shadow-inner focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
+                value={form.date}
+                max={todayInputValue()}
+                onChange={(event) => onFormChange('date', event.target.value)}
+                required
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-slate-200" htmlFor="savings-account">
+              Destination account
+            </label>
+            <select
+              id="savings-account"
+              className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 shadow-inner focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
+              value={form.accountId}
+              onChange={(event) => onFormChange('accountId', event.target.value)}
+              required
+            >
+              <option value="" disabled>
+                Select an account
+              </option>
+              {assetAccounts.map((account) => (
+                <option key={account.id} value={account.id}>
+                  {account.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-slate-200" htmlFor="savings-notes">
+              Notes (optional)
+            </label>
+            <textarea
+              id="savings-notes"
+              className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 shadow-inner focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
+              rows={3}
+              placeholder="Any context for this transfer"
+              value={form.notes}
+              onChange={(event) => onFormChange('notes', event.target.value)}
+            />
+          </div>
+
+          {error ? <p className="text-sm text-danger">{error}</p> : null}
+
+          <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+            <Button type="button" variant="secondary" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" isLoading={isSaving} disabled={isSaving}>
+              {isSaving ? 'Recording…' : 'Record savings'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/organisms/SavingsGauge/SavingsGauge.tsx
+++ b/src/components/organisms/SavingsGauge/SavingsGauge.tsx
@@ -1,0 +1,113 @@
+import type { Account, Currency, Transaction } from '../../../types';
+import { Button } from '../../atoms/Button';
+import { Card } from '../../atoms/Card';
+import { SectionHeading } from '../../atoms/SectionHeading';
+import { SavingsCaptureDialog } from './SavingsCaptureDialog';
+import { SavingsGaugeDial } from './SavingsGaugeDial';
+import { useSavingsCapture } from './useSavingsCapture';
+
+function formatCurrency(value: number, currency: Currency) {
+  return new Intl.NumberFormat('en-IN', {
+    style: 'currency',
+    currency,
+    maximumFractionDigits: 0
+  }).format(value);
+}
+
+type ManualTransactionInput = Omit<
+  Transaction,
+  'id' | 'createdAt' | 'updatedAt' | 'isRecurringMatch' | 'isPlannedMatch'
+>;
+
+interface SavingsGaugeProps {
+  savingsRate: number;
+  income: number;
+  expenses: number;
+  assetAccounts: Account[];
+  profileCurrency: Currency;
+  onRecordSavings: (payload: ManualTransactionInput) => Promise<Transaction>;
+}
+
+export function SavingsGauge({
+  savingsRate,
+  income,
+  expenses,
+  assetAccounts,
+  profileCurrency,
+  onRecordSavings
+}: SavingsGaugeProps) {
+  const {
+    form,
+    setForm,
+    isDialogOpen,
+    isSaving,
+    error,
+    showSaved,
+    openDialog,
+    closeDialog,
+    handleSubmit,
+    savingsDisabled,
+    requireAssetAccount
+  } = useSavingsCapture({ assetAccounts, profileCurrency, onRecordSavings });
+
+  return (
+    <Card className="relative p-6">
+      <SectionHeading>Savings &amp; Investment Rate</SectionHeading>
+      <p className="mt-1 text-sm text-slate-400">How efficiently is capital being deployed?</p>
+      <div className="mt-6 flex flex-col items-center gap-6 text-center sm:flex-row sm:text-left">
+        <SavingsGaugeDial savingsRate={savingsRate} />
+        <div className="space-y-2 text-sm">
+          <p>
+            <span className="text-slate-400">Income:</span> {formatCurrency(income, profileCurrency)}
+          </p>
+          <p>
+            <span className="text-slate-400">Expenses:</span> {formatCurrency(expenses, profileCurrency)}
+          </p>
+          <p>
+            <span className="text-slate-400">Savings:</span> {formatCurrency(income - expenses, profileCurrency)}
+          </p>
+          <p className="text-xs text-slate-500">Target ≥ 40% for aggressive wealth creation.</p>
+        </div>
+      </div>
+
+      <div className="mt-5 flex flex-col gap-3 sm:flex-row sm:items-center">
+        <Button
+          type="button"
+          onClick={() => {
+            if (savingsDisabled) {
+              requireAssetAccount();
+              return;
+            }
+            openDialog();
+          }}
+          variant="secondary"
+          disabled={savingsDisabled}
+        >
+          Record savings entry
+        </Button>
+        {showSaved ? (
+          <span className="text-xs font-medium text-emerald-300">Savings recorded and balances updated.</span>
+        ) : null}
+        {error && !isDialogOpen ? <span className="text-xs text-danger">{error}</span> : null}
+        {savingsDisabled ? (
+          <span className="text-xs text-slate-500">
+            Add an asset-linked account to include savings in your net worth.
+          </span>
+        ) : null}
+      </div>
+
+      <SavingsCaptureDialog
+        isOpen={isDialogOpen}
+        form={form}
+        isSaving={isSaving}
+        error={error}
+        assetAccounts={assetAccounts}
+        onClose={() => {
+          closeDialog();
+        }}
+        onSubmit={handleSubmit}
+        onFormChange={(field, value) => setForm((prev) => ({ ...prev, [field]: value }))}
+      />
+    </Card>
+  );
+}

--- a/src/components/organisms/SavingsGauge/SavingsGaugeDial.tsx
+++ b/src/components/organisms/SavingsGauge/SavingsGaugeDial.tsx
@@ -1,0 +1,33 @@
+interface SavingsGaugeDialProps {
+  savingsRate: number;
+}
+
+export function SavingsGaugeDial({ savingsRate }: SavingsGaugeDialProps) {
+  const clampedRate = Math.max(0, Math.min(150, savingsRate));
+  const radius = 15.9155;
+  const circumference = 2 * Math.PI * radius;
+  const dashOffset = circumference - (Math.min(100, Math.max(0, clampedRate)) / 100) * circumference;
+
+  return (
+    <div className="relative h-32 w-32">
+      <svg viewBox="0 0 36 36" className="h-full w-full">
+        <circle cx="18" cy="18" r={radius} fill="none" stroke="#1e293b" strokeWidth="3" />
+        <circle
+          cx="18"
+          cy="18"
+          r={radius}
+          fill="none"
+          stroke="#38bdf8"
+          strokeWidth="3"
+          strokeDasharray={`${circumference} ${circumference}`}
+          strokeDashoffset={dashOffset}
+          strokeLinecap="round"
+          transform="rotate(-90 18 18)"
+        />
+        <text x="18" y="20.35" className="fill-slate-100 text-base font-semibold" textAnchor="middle">
+          {savingsRate.toFixed(1)}%
+        </text>
+      </svg>
+    </div>
+  );
+}

--- a/src/components/organisms/SavingsGauge/index.ts
+++ b/src/components/organisms/SavingsGauge/index.ts
@@ -1,0 +1,1 @@
+export { SavingsGauge } from './SavingsGauge';

--- a/src/components/organisms/SavingsGauge/useSavingsCapture.ts
+++ b/src/components/organisms/SavingsGauge/useSavingsCapture.ts
@@ -1,0 +1,128 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { FormEventHandler } from 'react';
+import type { Account, Currency, Transaction } from '../../../types';
+
+type ManualTransactionInput = Omit<
+  Transaction,
+  'id' | 'createdAt' | 'updatedAt' | 'isRecurringMatch' | 'isPlannedMatch'
+>;
+
+interface UseSavingsCaptureOptions {
+  assetAccounts: Account[];
+  profileCurrency: Currency;
+  onRecordSavings: (payload: ManualTransactionInput) => Promise<Transaction>;
+}
+
+const initialFormState = (defaultAccountId: string) => ({
+  label: '',
+  amount: '',
+  accountId: defaultAccountId,
+  date: todayInputValue(),
+  notes: ''
+});
+
+export function useSavingsCapture({
+  assetAccounts,
+  profileCurrency,
+  onRecordSavings
+}: UseSavingsCaptureOptions) {
+  const defaultAccountId = useMemo(() => assetAccounts[0]?.id ?? '', [assetAccounts]);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showSaved, setShowSaved] = useState(false);
+  const [form, setForm] = useState(initialFormState(defaultAccountId));
+
+  useEffect(() => {
+    setForm((prev) => ({ ...prev, accountId: defaultAccountId }));
+  }, [defaultAccountId]);
+
+  useEffect(() => {
+    if (!showSaved) {
+      return;
+    }
+    const timeout = window.setTimeout(() => setShowSaved(false), 2800);
+    return () => window.clearTimeout(timeout);
+  }, [showSaved]);
+
+  const resetForm = () => {
+    setForm(initialFormState(defaultAccountId));
+    setError(null);
+  };
+
+  const closeDialog = () => {
+    setIsDialogOpen(false);
+    resetForm();
+  };
+
+  const openDialog = (message?: string) => {
+    setError(message ?? null);
+    setIsDialogOpen(true);
+  };
+
+  const handleSubmit: FormEventHandler<HTMLFormElement> = async (event) => {
+    event.preventDefault();
+    setError(null);
+
+    const amountValue = Number.parseFloat(form.amount);
+    if (!Number.isFinite(amountValue) || amountValue <= 0) {
+      setError('Enter a valid amount greater than zero.');
+      return;
+    }
+
+    if (!form.accountId) {
+      setError('Choose an account to park the savings.');
+      return;
+    }
+
+    const selectedAccount = assetAccounts.find((account) => account.id === form.accountId);
+    const currency = selectedAccount?.currency ?? profileCurrency;
+    const isoDate = new Date(`${form.date}T00:00:00`).toISOString();
+
+    setIsSaving(true);
+    try {
+      await onRecordSavings({
+        accountId: form.accountId,
+        amount: Math.abs(amountValue),
+        currency,
+        date: isoDate,
+        description: form.label.trim() ? form.label.trim() : 'Savings deposit',
+        notes: form.notes.trim() ? form.notes.trim() : undefined
+      });
+      setShowSaved(true);
+      closeDialog();
+    } catch (saveError) {
+      setError(saveError instanceof Error ? saveError.message : 'Unable to record savings right now.');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const savingsDisabled = assetAccounts.length === 0;
+
+  const requireAssetAccount = () =>
+    openDialog('Add a bank, cash, or investment account first to start tracking savings.');
+
+  return {
+    form,
+    setForm,
+    isDialogOpen,
+    isSaving,
+    error,
+    showSaved,
+    openDialog,
+    closeDialog,
+    handleSubmit,
+    resetForm,
+    savingsDisabled,
+    requireAssetAccount
+  };
+}
+
+export function todayInputValue() {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = `${now.getMonth() + 1}`.padStart(2, '0');
+  const day = `${now.getDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}

--- a/src/components/organisms/TopSpendingCategories.tsx
+++ b/src/components/organisms/TopSpendingCategories.tsx
@@ -1,0 +1,37 @@
+import type { Currency } from '../../types';
+import { Card } from '../atoms/Card';
+import { SectionHeading } from '../atoms/SectionHeading';
+
+type TopSpendingCategory = {
+  category: string;
+  total: number;
+};
+
+interface TopSpendingCategoriesProps {
+  items: TopSpendingCategory[];
+  currency?: Currency;
+}
+
+export function TopSpendingCategories({ items, currency = 'INR' }: TopSpendingCategoriesProps) {
+  const formatCurrency = (value: number) =>
+    new Intl.NumberFormat('en-IN', {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: 0
+    }).format(value);
+
+  return (
+    <Card className="p-5">
+      <SectionHeading className="mb-4">Top Spending Categories</SectionHeading>
+      <ol className="space-y-3 text-sm">
+        {items.map((item) => (
+          <li key={item.category} className="flex items-center justify-between">
+            <span className="text-slate-300">{item.category}</span>
+            <span className="font-semibold text-slate-100">{formatCurrency(item.total)}</span>
+          </li>
+        ))}
+        {items.length === 0 ? <p className="text-sm text-slate-500">No spending recorded yet.</p> : null}
+      </ol>
+    </Card>
+  );
+}

--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -1,0 +1,3 @@
+export function cn(...values: Array<string | false | null | undefined>) {
+  return values.filter(Boolean).join(' ');
+}

--- a/src/views/DashboardView.tsx
+++ b/src/views/DashboardView.tsx
@@ -1,12 +1,24 @@
-import { useEffect, useMemo, useState } from 'react';
-import { useFinancialStore } from '../store/FinancialStoreProvider';
-import { format } from 'date-fns';
+import { useMemo } from 'react';
 import { DataControlPanel } from '../components/DataControlPanel';
+import { MetricHighlight } from '../components/molecules/MetricHighlight';
+import { RecentTransactionsTable } from '../components/organisms/RecentTransactionsTable';
+import { SavingsGauge } from '../components/organisms/SavingsGauge';
+import { TopSpendingCategories } from '../components/organisms/TopSpendingCategories';
+import { useFinancialStore } from '../store/FinancialStoreProvider';
 import type { Account, Currency, Transaction } from '../types';
 
-function formatCurrency(value: number) {
-  return new Intl.NumberFormat('en-IN', { style: 'currency', currency: 'INR', maximumFractionDigits: 0 }).format(value);
+function formatCurrency(value: number, currency: Currency = 'INR') {
+  return new Intl.NumberFormat('en-IN', {
+    style: 'currency',
+    currency,
+    maximumFractionDigits: 0
+  }).format(value);
 }
+
+type ManualTransactionInput = Omit<
+  Transaction,
+  'id' | 'createdAt' | 'updatedAt' | 'isRecurringMatch' | 'isPlannedMatch'
+>;
 
 export function DashboardView() {
   const {
@@ -19,50 +31,17 @@ export function DashboardView() {
     addManualTransaction
   } = useFinancialStore();
 
-  const netWorth = useMemo(() => {
-    const assets = accounts
-      .filter(
-        (account) => account.type === 'bank' || account.type === 'investment' || account.type === 'cash'
-      )
-      .reduce((sum, account) => sum + account.balance, 0);
-    const liabilities = accounts
-      .filter((account) => account.type === 'loan' || account.type === 'credit-card')
-      .reduce((sum, account) => sum + account.balance, 0);
-    return assets - liabilities;
-  }, [accounts]);
+  const netWorth = useMemo(() => calculateNetWorth(accounts), [accounts]);
+  const savingsAccounts = useMemo(() => selectSavingsAccounts(accounts), [accounts]);
 
-  const savingsAccounts = useMemo(
-    () => accounts.filter((account) => account.type === 'bank' || account.type === 'investment' || account.type === 'cash'),
-    [accounts]
+  const { monthlyIncome, monthlyExpenses } = useMemo(
+    () => deriveMonthlyFlow(transactions, monthlyIncomes),
+    [transactions, monthlyIncomes]
   );
-
-  const { monthlyIncome, monthlyExpenses } = useMemo(() => {
-    const incomeFromTransactions = transactions
-      .filter((txn) => txn.amount > 0)
-      .reduce((sum, txn) => sum + txn.amount, 0);
-    const recurringIncome = monthlyIncomes.reduce((sum, income) => sum + income.amount, 0);
-    const expenses = transactions.filter((txn) => txn.amount < 0).reduce((sum, txn) => sum + Math.abs(txn.amount), 0);
-    return { monthlyIncome: incomeFromTransactions + recurringIncome, monthlyExpenses: expenses };
-  }, [transactions, monthlyIncomes]);
 
   const savingsRate = monthlyIncome > 0 ? ((monthlyIncome - monthlyExpenses) / monthlyIncome) * 100 : 0;
 
-  const topSpending = useMemo(() => {
-    const expenseByCategory = new Map<string, number>();
-    transactions
-      .filter((txn) => txn.amount < 0)
-      .forEach((txn) => {
-        const category = txn.categoryId ?? 'uncategorised';
-        expenseByCategory.set(category, (expenseByCategory.get(category) ?? 0) + Math.abs(txn.amount));
-      });
-    return Array.from(expenseByCategory.entries())
-      .map(([categoryId, total]) => ({
-        category: categories.find((cat) => cat.id === categoryId)?.name ?? 'Uncategorised',
-        total
-      }))
-      .sort((a, b) => b.total - a.total)
-      .slice(0, 5);
-  }, [transactions, categories]);
+  const topSpending = useMemo(() => computeTopSpending(transactions, categories), [transactions, categories]);
 
   const recentTransactions = useMemo(
     () =>
@@ -72,13 +51,28 @@ export function DashboardView() {
     [transactions]
   );
 
+  const resolveCategoryName = (categoryId: string | undefined) =>
+    categories.find((cat) => cat.id === categoryId)?.name ?? 'Uncategorised';
+
   return (
     <div className="space-y-6">
       <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-        <MetricCard title="Total Net Worth" value={formatCurrency(netWorth)} subtitle="Assets - Liabilities" />
-        <MetricCard title="Monthly Income" value={formatCurrency(monthlyIncome)} subtitle="Cash inflows" />
-        <MetricCard title="Monthly Expenses" value={formatCurrency(monthlyExpenses)} subtitle="Cash outflows" />
-        <MetricCard
+        <MetricHighlight
+          title="Total Net Worth"
+          value={formatCurrency(netWorth, profile?.currency ?? 'INR')}
+          subtitle="Assets - Liabilities"
+        />
+        <MetricHighlight
+          title="Monthly Income"
+          value={formatCurrency(monthlyIncome, profile?.currency ?? 'INR')}
+          subtitle="Cash inflows"
+        />
+        <MetricHighlight
+          title="Monthly Expenses"
+          value={formatCurrency(monthlyExpenses, profile?.currency ?? 'INR')}
+          subtitle="Cash outflows"
+        />
+        <MetricHighlight
           title="Capital Efficiency"
           value={`${wealthMetrics.capitalEfficiencyScore}%`}
           subtitle="Wealth Accelerator score"
@@ -92,400 +86,56 @@ export function DashboardView() {
           expenses={monthlyExpenses}
           assetAccounts={savingsAccounts}
           profileCurrency={profile?.currency ?? 'INR'}
-          onRecordSavings={addManualTransaction}
+          onRecordSavings={(payload: ManualTransactionInput) => addManualTransaction(payload)}
         />
-        <TopSpendingCategories items={topSpending} />
+        <TopSpendingCategories items={topSpending} currency={profile?.currency ?? 'INR'} />
       </section>
 
       <DataControlPanel />
 
-      <section>
-        <h2 className="mb-3 text-lg font-semibold">Recent Transactions</h2>
-        <div className="rounded-2xl border border-slate-800">
-          <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-slate-800 text-sm">
-            <thead className="bg-slate-900/80 text-xs uppercase text-slate-400">
-              <tr>
-                <th className="px-4 py-3 text-left">Date</th>
-                <th className="px-4 py-3 text-left">Description</th>
-                <th className="px-4 py-3 text-left">Category</th>
-                <th className="px-4 py-3 text-right">Amount</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-slate-800">
-              {recentTransactions.map((txn) => {
-                const category = categories.find((cat) => cat.id === txn.categoryId)?.name ?? 'Uncategorised';
-                return (
-                  <tr key={txn.id} className="hover:bg-slate-800/40">
-                    <td className="px-4 py-3">{format(new Date(txn.date), 'd MMM')}</td>
-                    <td className="px-4 py-3">{txn.description}</td>
-                    <td className="px-4 py-3">{category}</td>
-                    <td className={`px-4 py-3 text-right ${txn.amount < 0 ? 'text-danger' : 'text-success'}`}>
-                      {formatCurrency(txn.amount)}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-            </table>
-          </div>
-        </div>
-      </section>
+      <RecentTransactionsTable
+        transactions={recentTransactions}
+        resolveCategoryName={resolveCategoryName}
+        formatCurrency={(value) => formatCurrency(value, profile?.currency ?? 'INR')}
+      />
     </div>
   );
 }
 
-function MetricCard({ title, value, subtitle }: { title: string; value: string; subtitle: string }) {
-  return (
-    <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-5 shadow">
-      <p className="text-xs uppercase tracking-wide text-slate-400">{title}</p>
-      <p className="mt-2 text-2xl font-semibold text-slate-100">{value}</p>
-      <p className="text-xs text-slate-500">{subtitle}</p>
-    </div>
-  );
+function calculateNetWorth(accounts: Account[]) {
+  const assets = accounts
+    .filter((account) => account.type === 'bank' || account.type === 'investment' || account.type === 'cash')
+    .reduce((sum, account) => sum + account.balance, 0);
+  const liabilities = accounts
+    .filter((account) => account.type === 'loan' || account.type === 'credit-card')
+    .reduce((sum, account) => sum + account.balance, 0);
+  return assets - liabilities;
 }
 
-type ManualTransactionInput = Omit<
-  Transaction,
-  'id' | 'createdAt' | 'updatedAt' | 'isRecurringMatch' | 'isPlannedMatch'
->;
-
-interface SavingsGaugeProps {
-  savingsRate: number;
-  income: number;
-  expenses: number;
-  assetAccounts: Account[];
-  profileCurrency: Currency;
-  onRecordSavings: (payload: ManualTransactionInput) => Promise<Transaction>;
+function selectSavingsAccounts(accounts: Account[]) {
+  return accounts.filter((account) => account.type === 'bank' || account.type === 'investment' || account.type === 'cash');
 }
 
-function SavingsGauge({
-  savingsRate,
-  income,
-  expenses,
-  assetAccounts,
-  profileCurrency,
-  onRecordSavings
-}: SavingsGaugeProps) {
-  const clampedRate = Math.max(0, Math.min(150, savingsRate));
-  const radius = 15.9155;
-  const circumference = 2 * Math.PI * radius;
-  const dashOffset = circumference - (Math.min(100, Math.max(0, clampedRate)) / 100) * circumference;
+function deriveMonthlyFlow(transactions: Transaction[], monthlyIncomes: Array<{ amount: number }>) {
+  const incomeFromTransactions = transactions.filter((txn) => txn.amount > 0).reduce((sum, txn) => sum + txn.amount, 0);
+  const recurringIncome = monthlyIncomes.reduce((sum, income) => sum + income.amount, 0);
+  const expenses = transactions.filter((txn) => txn.amount < 0).reduce((sum, txn) => sum + Math.abs(txn.amount), 0);
+  return { monthlyIncome: incomeFromTransactions + recurringIncome, monthlyExpenses: expenses };
+}
 
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const [form, setForm] = useState({
-    label: '',
-    amount: '',
-    accountId: assetAccounts[0]?.id ?? '',
-    date: todayInputValue(),
-    notes: ''
-  });
-  const [isSaving, setIsSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [showSaved, setShowSaved] = useState(false);
-
-  useEffect(() => {
-    if (!assetAccounts.length) {
-      setForm((prev) => ({ ...prev, accountId: '' }));
-      return;
-    }
-    if (!assetAccounts.find((account) => account.id === form.accountId)) {
-      setForm((prev) => ({ ...prev, accountId: assetAccounts[0]?.id ?? '' }));
-    }
-  }, [assetAccounts, form.accountId]);
-
-  useEffect(() => {
-    if (!showSaved) {
-      return;
-    }
-    const timeout = window.setTimeout(() => setShowSaved(false), 2800);
-    return () => window.clearTimeout(timeout);
-  }, [showSaved]);
-
-  const resetForm = () => {
-    setForm({
-      label: '',
-      amount: '',
-      accountId: assetAccounts[0]?.id ?? '',
-      date: todayInputValue(),
-      notes: ''
+function computeTopSpending(transactions: Transaction[], categories: Array<{ id: string; name: string }>) {
+  const expenseByCategory = new Map<string, number>();
+  transactions
+    .filter((txn) => txn.amount < 0)
+    .forEach((txn) => {
+      const category = txn.categoryId ?? 'uncategorised';
+      expenseByCategory.set(category, (expenseByCategory.get(category) ?? 0) + Math.abs(txn.amount));
     });
-    setError(null);
-  };
-
-  const handleSubmit: React.FormEventHandler<HTMLFormElement> = async (event) => {
-    event.preventDefault();
-    setError(null);
-
-    const amountValue = Number.parseFloat(form.amount);
-    if (!Number.isFinite(amountValue) || amountValue <= 0) {
-      setError('Enter a valid amount greater than zero.');
-      return;
-    }
-
-    if (!form.accountId) {
-      setError('Choose an account to park the savings.');
-      return;
-    }
-
-    const selectedAccount = assetAccounts.find((account) => account.id === form.accountId);
-    const currency = selectedAccount?.currency ?? profileCurrency;
-    const isoDate = new Date(`${form.date}T00:00:00`).toISOString();
-
-    setIsSaving(true);
-    try {
-      await onRecordSavings({
-        accountId: form.accountId,
-        amount: Math.abs(amountValue),
-        currency,
-        date: isoDate,
-        description: form.label.trim() ? form.label.trim() : 'Savings deposit',
-        notes: form.notes.trim() ? form.notes.trim() : undefined
-      });
-      setShowSaved(true);
-      resetForm();
-      setIsDialogOpen(false);
-    } catch (saveError) {
-      setError(saveError instanceof Error ? saveError.message : 'Unable to record savings right now.');
-    } finally {
-      setIsSaving(false);
-    }
-  };
-
-  const savingsDisabled = assetAccounts.length === 0;
-
-  return (
-    <div className="relative rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
-      <h2 className="text-lg font-semibold">Savings & Investment Rate</h2>
-      <p className="mt-1 text-sm text-slate-400">How efficiently is capital being deployed?</p>
-      <div className="mt-6 flex flex-col items-center gap-6 text-center sm:flex-row sm:text-left">
-        <div className="relative h-32 w-32">
-          <svg viewBox="0 0 36 36" className="h-full w-full">
-            <circle cx="18" cy="18" r={radius} fill="none" stroke="#1e293b" strokeWidth="3" />
-            <circle
-              cx="18"
-              cy="18"
-              r={radius}
-              fill="none"
-              stroke="#38bdf8"
-              strokeWidth="3"
-              strokeDasharray={`${circumference} ${circumference}`}
-              strokeDashoffset={dashOffset}
-              strokeLinecap="round"
-              transform="rotate(-90 18 18)"
-            />
-            <text x="18" y="20.35" className="fill-slate-100 text-base font-semibold" textAnchor="middle">
-              {savingsRate.toFixed(1)}%
-            </text>
-          </svg>
-        </div>
-        <div className="space-y-2 text-sm">
-          <p>
-            <span className="text-slate-400">Income:</span> {formatCurrency(income)}
-          </p>
-          <p>
-            <span className="text-slate-400">Expenses:</span> {formatCurrency(expenses)}
-          </p>
-          <p>
-            <span className="text-slate-400">Savings:</span> {formatCurrency(income - expenses)}
-          </p>
-          <p className="text-xs text-slate-500">Target ≥ 40% for aggressive wealth creation.</p>
-        </div>
-      </div>
-
-      <div className="mt-5 flex flex-col gap-3 sm:flex-row sm:items-center">
-        <button
-          type="button"
-          onClick={() => {
-            if (savingsDisabled) {
-              setError('Add a bank, cash, or investment account first to start tracking savings.');
-              setIsDialogOpen(true);
-              return;
-            }
-            setError(null);
-            setIsDialogOpen(true);
-          }}
-          className="inline-flex items-center justify-center rounded-lg bg-emerald-500 px-4 py-2 text-sm font-semibold text-emerald-950 transition hover:bg-emerald-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-200 disabled:cursor-not-allowed disabled:bg-emerald-800/60 disabled:text-emerald-200/70"
-          disabled={savingsDisabled}
-        >
-          Record savings entry
-        </button>
-        {showSaved ? (
-          <span className="text-xs font-medium text-emerald-300">Savings recorded and balances updated.</span>
-        ) : null}
-        {error && !isDialogOpen ? (
-          <span className="text-xs text-danger">{error}</span>
-        ) : null}
-        {savingsDisabled ? (
-          <span className="text-xs text-slate-500">
-            Add an asset-linked account to include savings in your net worth.
-          </span>
-        ) : null}
-      </div>
-
-      {isDialogOpen ? (
-        <div className="fixed inset-0 z-40 flex items-center justify-center bg-slate-950/80 p-4">
-          <div className="w-full max-w-lg rounded-2xl border border-slate-700 bg-slate-900/95 p-6 shadow-2xl">
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <h3 className="text-lg font-semibold text-emerald-300">Record a savings transfer</h3>
-                <p className="mt-1 text-sm text-slate-400">
-                  Move surplus income into your asset accounts so the balance reflects in Total Net Worth.
-                </p>
-              </div>
-              <button
-                type="button"
-                onClick={() => {
-                  setIsDialogOpen(false);
-                  setError(null);
-                  resetForm();
-                }}
-                className="rounded-full border border-transparent p-1 text-slate-400 transition hover:text-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-200"
-                aria-label="Close"
-              >
-                ✕
-              </button>
-            </div>
-
-            <form onSubmit={handleSubmit} className="mt-6 space-y-5">
-              <div>
-                <label className="block text-sm font-medium text-slate-200" htmlFor="savings-label">
-                  Savings label
-                </label>
-                <input
-                  id="savings-label"
-                  type="text"
-                  className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 shadow-inner focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
-                  placeholder="e.g. Emergency fund top-up"
-                  value={form.label}
-                  onChange={(event) => setForm((prev) => ({ ...prev, label: event.target.value }))}
-                />
-              </div>
-
-              <div className="grid gap-4 sm:grid-cols-2">
-                <div>
-                  <label className="block text-sm font-medium text-slate-200" htmlFor="savings-amount">
-                    Amount
-                  </label>
-                  <input
-                    id="savings-amount"
-                    type="number"
-                    min="0"
-                    step="0.01"
-                    className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 shadow-inner focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
-                    placeholder="50000"
-                    value={form.amount}
-                    onChange={(event) => setForm((prev) => ({ ...prev, amount: event.target.value }))}
-                    required
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-slate-200" htmlFor="savings-date">
-                    Transfer date
-                  </label>
-                  <input
-                    id="savings-date"
-                    type="date"
-                    className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 shadow-inner focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
-                    value={form.date}
-                    max={todayInputValue()}
-                    onChange={(event) => setForm((prev) => ({ ...prev, date: event.target.value }))}
-                    required
-                  />
-                </div>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-slate-200" htmlFor="savings-account">
-                  Destination account
-                </label>
-                <select
-                  id="savings-account"
-                  className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 shadow-inner focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
-                  value={form.accountId}
-                  onChange={(event) => setForm((prev) => ({ ...prev, accountId: event.target.value }))}
-                  required
-                >
-                  <option value="" disabled>
-                    Select an account
-                  </option>
-                  {assetAccounts.map((account) => (
-                    <option key={account.id} value={account.id}>
-                      {account.name}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-slate-200" htmlFor="savings-notes">
-                  Notes (optional)
-                </label>
-                <textarea
-                  id="savings-notes"
-                  className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 shadow-inner focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
-                  rows={3}
-                  placeholder="Any context for this transfer"
-                  value={form.notes}
-                  onChange={(event) => setForm((prev) => ({ ...prev, notes: event.target.value }))}
-                />
-              </div>
-
-              {error ? <p className="text-sm text-danger">{error}</p> : null}
-
-              <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
-                <button
-                  type="button"
-                  onClick={() => {
-                    setIsDialogOpen(false);
-                    setError(null);
-                    resetForm();
-                  }}
-                  className="rounded-lg border border-slate-700 px-4 py-2 text-sm font-medium text-slate-200 transition hover:bg-slate-800"
-                >
-                  Cancel
-                </button>
-                <button
-                  type="submit"
-                  disabled={isSaving}
-                  className="inline-flex items-center justify-center rounded-lg bg-emerald-500 px-4 py-2 text-sm font-semibold text-emerald-950 transition hover:bg-emerald-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-200 disabled:cursor-not-allowed disabled:bg-emerald-700/60 disabled:text-emerald-200"
-                >
-                  {isSaving ? 'Recording…' : 'Record savings'}
-                </button>
-              </div>
-            </form>
-          </div>
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-function todayInputValue() {
-  const now = new Date();
-  const year = now.getFullYear();
-  const month = `${now.getMonth() + 1}`.padStart(2, '0');
-  const day = `${now.getDate()}`.padStart(2, '0');
-  return `${year}-${month}-${day}`;
-}
-
-function TopSpendingCategories({
-  items
-}: {
-  items: { category: string; total: number }[];
-}) {
-  return (
-    <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
-      <h2 className="text-lg font-semibold">Top Spending Categories</h2>
-      <ul className="mt-4 space-y-3 text-sm">
-        {items.map((item) => (
-          <li key={item.category} className="flex items-center justify-between">
-            <span>{item.category}</span>
-            <span className="font-semibold text-danger">{formatCurrency(item.total)}</span>
-          </li>
-        ))}
-        {items.length === 0 && <p className="text-sm text-slate-500">No expenses recorded yet.</p>}
-      </ul>
-    </div>
-  );
+  return Array.from(expenseByCategory.entries())
+    .map(([categoryId, total]) => ({
+      category: categories.find((cat) => cat.id === categoryId)?.name ?? 'Uncategorised',
+      total
+    }))
+    .sort((a, b) => b.total - a.total)
+    .slice(0, 5);
 }


### PR DESCRIPTION
## Summary
- refactor the application shell to use reusable atoms, molecules, and organisms for navigation and layout
- extract dashboard metrics, savings gauge, and transactions table into modular components with shared hooks
- add a class name utility to simplify styling composition across components

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e20ff245a4832cb872448a8ba9ac27