### PR TITLE
Fix Smart Budgeting sidebar shrinking on medium screens

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,7 +67,7 @@ export default function App() {
       <div className="mx-auto flex max-w-7xl flex-col gap-6 px-4 py-8 sm:px-6 md:flex-row">
         <nav
           id="primary-navigation"
-          className={`flex flex-col gap-2 overflow-hidden rounded-2xl border border-slate-800 bg-slate-900/70 p-4 shadow transition-all md:max-w-xs md:border-0 md:bg-transparent md:p-0 md:shadow-none ${
+          className={`flex flex-col gap-2 overflow-hidden rounded-2xl border border-slate-800 bg-slate-900/70 p-4 shadow transition-all md:w-64 md:flex-shrink-0 md:border-0 md:bg-transparent md:p-0 md:shadow-none ${
             isNavOpen ? 'max-h-[32rem] opacity-100' : 'max-h-0 opacity-0 md:max-h-full md:opacity-100'
           } md:flex`}
         >


### PR DESCRIPTION
## Summary
- prevent the primary navigation from shrinking on desktop breakpoints by assigning a fixed width

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e210f10c04832cb6fdae8ffc53fba1