### PR TITLE
Refactor budget planning into monthly collections

### DIFF
--- a/src/features/smart-budgeting/hooks/useSmartBudgetingController.tsx
+++ b/src/features/smart-budgeting/hooks/useSmartBudgetingController.tsx
@@ -78,7 +78,7 @@ function generateEntryId() {
 
 export function useSmartBudgetingController() {
   const {
-    plannedExpenses,
+    allBudgetedPlannedExpenses,
     categories,
     transactions,
     addPlannedExpense,
@@ -267,7 +267,7 @@ export function useSmartBudgetingController() {
 
   const periodPlannedExpenses = useMemo(
     () =>
-      plannedExpenses.filter((item) => {
+      allBudgetedPlannedExpenses.filter((item) => {
         if (item.status === 'cancelled') {
           return false;
         }
@@ -276,7 +276,7 @@ export function useSmartBudgetingController() {
           ? monthKey(referenceDate) === selectedMonth
           : yearKey(referenceDate) === selectedYear;
       }),
-    [plannedExpenses, viewMode, selectedMonth, selectedYear]
+    [allBudgetedPlannedExpenses, viewMode, selectedMonth, selectedYear]
   );
 
   const periodTransactions = useMemo(

--- a/src/services/indexedDbService.test.ts
+++ b/src/services/indexedDbService.test.ts
@@ -58,6 +58,7 @@ const buildSnapshot = (timestamp: string): FinancialSnapshot => ({
     }
   ],
   plannedExpenses: [],
+  budgetMonths: {},
   recurringExpenses: [],
   goals: [],
   insights: [

--- a/src/store/FinancialStoreProvider.tsx
+++ b/src/store/FinancialStoreProvider.tsx
@@ -11,6 +11,8 @@ import {
 } from 'react';
 import type {
   Account,
+  BudgetMonth,
+  BudgetMonthTotals,
   Category,
   ExportEvent,
   FinancialSnapshot,
@@ -62,6 +64,117 @@ const normaliseOptionalNumber = (value: number | null | undefined): number | nul
     return null;
   }
   return value;
+};
+
+const budgetMonthKey = (date?: string | null): string => {
+  if (!date) {
+    return new Date().toISOString().slice(0, 7);
+  }
+  return date.slice(0, 7);
+};
+
+const emptyTotals = (): BudgetMonthTotals => ({
+  planned: 0,
+  actual: 0,
+  recurring: 0,
+  rollover: 0,
+  unassignedActuals: 0,
+  variance: 0
+});
+
+const createBudgetMonth = (month: string, timestamp: string): BudgetMonth => ({
+  month,
+  createdAt: timestamp,
+  updatedAt: timestamp,
+  plannedExpenses: [],
+  recurringAllocations: [],
+  rollovers: [],
+  unassignedActuals: [],
+  totals: emptyTotals()
+});
+
+const cloneBudgetMonth = (month: BudgetMonth, timestamp: string, key: string): BudgetMonth => ({
+  ...month,
+  month: month.month ?? key,
+  plannedExpenses: [...(month.plannedExpenses ?? [])],
+  recurringAllocations: [...(month.recurringAllocations ?? [])],
+  rollovers: [...(month.rollovers ?? [])],
+  unassignedActuals: [...(month.unassignedActuals ?? [])],
+  totals: { ...(month.totals ?? emptyTotals()) },
+  updatedAt: timestamp
+});
+
+const computeBudgetTotals = (month: BudgetMonth): BudgetMonthTotals => {
+  const planned = month.plannedExpenses.reduce((sum, item) => sum + item.plannedAmount, 0);
+  const actual = month.plannedExpenses.reduce((sum, item) => sum + (item.actualAmount ?? 0), 0);
+  const recurring = month.recurringAllocations.reduce((sum, item) => sum + item.amount, 0);
+  const rollover = month.rollovers.reduce((sum, item) => sum + (item.remainderAmount ?? 0), 0);
+  const unassignedActuals = month.unassignedActuals.reduce((sum, item) => sum + item.amount, 0);
+  const variance = planned + recurring + rollover - actual - unassignedActuals;
+  return { planned, actual, recurring, rollover, unassignedActuals, variance };
+};
+
+export const ensureBudgetMonth = (
+  snapshot: FinancialSnapshot,
+  key: string
+): FinancialSnapshot => {
+  if (!key) {
+    return snapshot;
+  }
+  const existing = snapshot.budgetMonths?.[key];
+  if (existing) {
+    return snapshot;
+  }
+  const timestamp = new Date().toISOString();
+  return {
+    ...snapshot,
+    budgetMonths: {
+      ...snapshot.budgetMonths,
+      [key]: createBudgetMonth(key, timestamp)
+    }
+  };
+};
+
+export const recomputeBudgetMonth = (
+  snapshot: FinancialSnapshot,
+  key: string
+): FinancialSnapshot => {
+  if (!key) {
+    return snapshot;
+  }
+  const current = snapshot.budgetMonths[key];
+  if (!current) {
+    return snapshot;
+  }
+  const timestamp = new Date().toISOString();
+  const nextMonth = cloneBudgetMonth(current, timestamp, key);
+  nextMonth.recurringAllocations = snapshot.recurringExpenses.filter((expense) => {
+    const reference = expense.nextDueDate ?? expense.dueDate ?? expense.createdAt;
+    return budgetMonthKey(reference) === key;
+  });
+  nextMonth.totals = computeBudgetTotals(nextMonth);
+  return {
+    ...snapshot,
+    budgetMonths: {
+      ...snapshot.budgetMonths,
+      [key]: nextMonth
+    }
+  };
+};
+
+const flattenBudgetMonths = (months: Record<string, BudgetMonth>): PlannedExpenseItem[] =>
+  Object.values(months).flatMap((month) => month.plannedExpenses);
+
+const findPlannedExpenseMonthKey = (
+  snapshot: FinancialSnapshot,
+  id: string
+): string | undefined => {
+  for (const [key, month] of Object.entries(snapshot.budgetMonths)) {
+    if (month.plannedExpenses.some((item) => item.id === id)) {
+      return key;
+    }
+  }
+  return undefined;
 };
 
 interface InitialSetupPayload {
@@ -137,7 +250,14 @@ interface FinancialStoreActions {
   resetLedger(): Promise<void>;
 }
 
-type FinancialStoreContextValue = FinancialStoreState & FinancialStoreActions;
+interface FinancialStoreSelectors {
+  budgetMonthsList: BudgetMonth[];
+  allBudgetedPlannedExpenses: PlannedExpenseItem[];
+  getBudgetMonth: (monthKey: string) => BudgetMonth | undefined;
+  budgetSummary: BudgetMonthTotals;
+}
+
+type FinancialStoreContextValue = FinancialStoreState & FinancialStoreActions & FinancialStoreSelectors;
 
 type FinancialReducerAction =
   | { type: 'replace'; state: FinancialStoreState }
@@ -185,6 +305,7 @@ const createDefaultSnapshot = (): FinancialSnapshot => {
     transactions: [],
     monthlyIncomes: [],
     plannedExpenses: [],
+    budgetMonths: {},
     recurringExpenses: [],
     goals: [],
     insights: [],
@@ -203,26 +324,75 @@ const createDefaultSnapshot = (): FinancialSnapshot => {
 
 const deriveFromSnapshot = (snapshot: FinancialSnapshot): FinancialSnapshot => {
   const now = new Date().toISOString();
+  let working: FinancialSnapshot = {
+    ...snapshot,
+    budgetMonths: { ...snapshot.budgetMonths }
+  };
+  const touchedMonths = new Set<string>();
+
+  if (working.plannedExpenses.length > 0) {
+    for (const expense of working.plannedExpenses) {
+      const key = budgetMonthKey(expense.dueDate ?? expense.createdAt);
+      touchedMonths.add(key);
+      working = ensureBudgetMonth(working, key);
+      const month = working.budgetMonths[key];
+      const timestampedExpense: PlannedExpenseItem = {
+        ...expense,
+        createdAt: expense.createdAt ?? now,
+        updatedAt: expense.updatedAt ?? now
+      };
+      const index = month.plannedExpenses.findIndex((item) => item.id === expense.id);
+      const plannedExpenses = index >= 0
+        ? month.plannedExpenses.map((item) => (item.id === expense.id ? timestampedExpense : item))
+        : [...month.plannedExpenses, timestampedExpense];
+      working = {
+        ...working,
+        budgetMonths: {
+          ...working.budgetMonths,
+          [key]: {
+            ...month,
+            plannedExpenses
+          }
+        }
+      };
+    }
+    working = { ...working, plannedExpenses: [] };
+  }
+
+  for (const expense of working.recurringExpenses) {
+    const key = budgetMonthKey(expense.nextDueDate ?? expense.dueDate ?? expense.createdAt);
+    touchedMonths.add(key);
+    working = ensureBudgetMonth(working, key);
+  }
+
+  Object.keys(working.budgetMonths).forEach((key) => touchedMonths.add(key));
+
+  for (const key of touchedMonths) {
+    working = recomputeBudgetMonth(working, key);
+  }
+
+  const flattenedPlanned = flattenBudgetMonths(working.budgetMonths);
+
   const wealthMetrics = {
     ...simulateWealthAccelerator(
-      snapshot.accounts,
-      snapshot.transactions,
-      snapshot.goals,
-      snapshot.recurringExpenses,
-      snapshot.monthlyIncomes
+      working.accounts,
+      working.transactions,
+      working.goals,
+      working.recurringExpenses,
+      working.monthlyIncomes
     ),
     updatedAt: now
   };
 
   const insights: Insight[] = generateInsights({
-    accounts: snapshot.accounts,
-    transactions: snapshot.transactions,
-    recurringExpenses: snapshot.recurringExpenses,
-    plannedExpenses: snapshot.plannedExpenses,
-    goals: snapshot.goals,
-    categories: snapshot.categories,
-    monthlyIncomes: snapshot.monthlyIncomes,
-    currency: snapshot.profile?.currency
+    accounts: working.accounts,
+    transactions: working.transactions,
+    recurringExpenses: working.recurringExpenses,
+    plannedExpenses: flattenedPlanned,
+    goals: working.goals,
+    categories: working.categories,
+    monthlyIncomes: working.monthlyIncomes,
+    currency: working.profile?.currency
   }).map((insight) => ({
     ...insight,
     createdAt: insight.createdAt ?? now,
@@ -230,7 +400,8 @@ const deriveFromSnapshot = (snapshot: FinancialSnapshot): FinancialSnapshot => {
   }));
 
   return normaliseSnapshot({
-    ...snapshot,
+    ...working,
+    plannedExpenses: [],
     wealthMetrics,
     insights
   });
@@ -242,7 +413,14 @@ const isSnapshotInitialised = (snapshot: Partial<FinancialSnapshot>): boolean =>
       (snapshot.accounts && snapshot.accounts.length > 0) ||
       (snapshot.transactions && snapshot.transactions.length > 0) ||
       (snapshot.monthlyIncomes && snapshot.monthlyIncomes.length > 0) ||
-      (snapshot.plannedExpenses && snapshot.plannedExpenses.length > 0) ||
+      (snapshot.budgetMonths &&
+        Object.values(snapshot.budgetMonths).some(
+          (month) =>
+            month?.plannedExpenses?.length ||
+            month?.recurringAllocations?.length ||
+            month?.totals?.planned ||
+            month?.totals?.recurring
+        )) ||
       (snapshot.recurringExpenses && snapshot.recurringExpenses.length > 0)
   );
 
@@ -313,6 +491,7 @@ function toSnapshot(value: FinancialStoreState): FinancialSnapshot {
     transactions: value.transactions,
     monthlyIncomes: value.monthlyIncomes,
     plannedExpenses: value.plannedExpenses,
+    budgetMonths: value.budgetMonths,
     recurringExpenses: value.recurringExpenses,
     goals: value.goals,
     insights: value.insights,
@@ -638,31 +817,100 @@ function useFinancialActions(container: FinancialStoreContainer): FinancialStore
         createdAt: now,
         updatedAt: now
       };
-      await persistAndSet((snapshot) => ({
-        ...snapshot,
-        plannedExpenses: [...snapshot.plannedExpenses, item]
-      }));
+      await persistAndSet((snapshot) => {
+        const key = budgetMonthKey(item.dueDate ?? item.createdAt);
+        let next = ensureBudgetMonth(snapshot, key);
+        const month = next.budgetMonths[key];
+        next = {
+          ...next,
+          budgetMonths: {
+            ...next.budgetMonths,
+            [key]: {
+              ...month,
+              plannedExpenses: [...month.plannedExpenses, item]
+            }
+          },
+          plannedExpenses: []
+        };
+        return recomputeBudgetMonth(next, key);
+      });
       return item;
     },
     async updatePlannedExpense(id, payload) {
-      await persistAndSet((snapshot) => ({
-        ...snapshot,
-        plannedExpenses: snapshot.plannedExpenses.map((expense) =>
-          expense.id === id
-            ? {
-                ...expense,
-                ...payload,
-                updatedAt: new Date().toISOString()
-              }
-            : expense
-        )
-      }));
+      await persistAndSet((snapshot) => {
+        const monthKey = findPlannedExpenseMonthKey(snapshot, id);
+        if (!monthKey) {
+          return snapshot;
+        }
+        const currentMonth = snapshot.budgetMonths[monthKey];
+        const currentExpense = currentMonth.plannedExpenses.find((expense) => expense.id === id);
+        if (!currentExpense) {
+          return snapshot;
+        }
+        const now = new Date().toISOString();
+        const updatedExpense: PlannedExpenseItem = {
+          ...currentExpense,
+          ...payload,
+          updatedAt: now
+        };
+        const nextMonthKey = budgetMonthKey(updatedExpense.dueDate ?? updatedExpense.createdAt);
+        const touched = new Set([monthKey, nextMonthKey]);
+        let next = ensureBudgetMonth(snapshot, nextMonthKey);
+        const withoutCurrent = next.budgetMonths[monthKey].plannedExpenses.filter((expense) => expense.id !== id);
+        next = {
+          ...next,
+          budgetMonths: {
+            ...next.budgetMonths,
+            [monthKey]: {
+              ...next.budgetMonths[monthKey],
+              plannedExpenses: withoutCurrent
+            }
+          },
+          plannedExpenses: []
+        };
+        const destinationMonth = next.budgetMonths[nextMonthKey];
+        const existingIndex = destinationMonth.plannedExpenses.findIndex((expense) => expense.id === id);
+        const updatedPlanned = existingIndex >= 0
+          ? destinationMonth.plannedExpenses.map((expense) => (expense.id === id ? updatedExpense : expense))
+          : [...destinationMonth.plannedExpenses, updatedExpense];
+        next = {
+          ...next,
+          budgetMonths: {
+            ...next.budgetMonths,
+            [nextMonthKey]: {
+              ...destinationMonth,
+              plannedExpenses: updatedPlanned
+            }
+          }
+        };
+        for (const key of touched) {
+          next = recomputeBudgetMonth(next, key);
+        }
+        return next;
+      });
     },
     async deletePlannedExpense(id) {
-      await persistAndSet((snapshot) => ({
-        ...snapshot,
-        plannedExpenses: snapshot.plannedExpenses.filter((expense) => expense.id !== id)
-      }));
+      await persistAndSet((snapshot) => {
+        const monthKey = findPlannedExpenseMonthKey(snapshot, id);
+        if (!monthKey) {
+          return snapshot;
+        }
+        const month = snapshot.budgetMonths[monthKey];
+        const plannedExpenses = month.plannedExpenses.filter((expense) => expense.id !== id);
+        let next: FinancialSnapshot = {
+          ...snapshot,
+          budgetMonths: {
+            ...snapshot.budgetMonths,
+            [monthKey]: {
+              ...month,
+              plannedExpenses
+            }
+          },
+          plannedExpenses: []
+        };
+        next = recomputeBudgetMonth(next, monthKey);
+        return next;
+      });
     },
     async addRecurringExpense(payload) {
       const now = new Date().toISOString();
@@ -672,31 +920,63 @@ function useFinancialActions(container: FinancialStoreContainer): FinancialStore
         createdAt: now,
         updatedAt: now
       };
-      await persistAndSet((snapshot) => ({
-        ...snapshot,
-        recurringExpenses: [...snapshot.recurringExpenses, expense]
-      }));
+      await persistAndSet((snapshot) => {
+        const key = budgetMonthKey(expense.nextDueDate ?? expense.dueDate ?? expense.createdAt);
+        let next: FinancialSnapshot = {
+          ...snapshot,
+          recurringExpenses: [...snapshot.recurringExpenses, expense]
+        };
+        next = ensureBudgetMonth(next, key);
+        next = recomputeBudgetMonth(next, key);
+        return next;
+      });
       return expense;
     },
     async updateRecurringExpense(id, payload) {
-      await persistAndSet((snapshot) => ({
-        ...snapshot,
-        recurringExpenses: snapshot.recurringExpenses.map((expense) =>
-          expense.id === id
-            ? {
-                ...expense,
-                ...payload,
-                updatedAt: new Date().toISOString()
-              }
-            : expense
-        )
-      }));
+      await persistAndSet((snapshot) => {
+        const existing = snapshot.recurringExpenses.find((expense) => expense.id === id);
+        if (!existing) {
+          return snapshot;
+        }
+        const now = new Date().toISOString();
+        const updatedExpense: RecurringExpense = {
+          ...existing,
+          ...payload,
+          updatedAt: now
+        };
+        let next: FinancialSnapshot = {
+          ...snapshot,
+          recurringExpenses: snapshot.recurringExpenses.map((expense) =>
+            expense.id === id ? updatedExpense : expense
+          )
+        };
+        const previousKey = budgetMonthKey(existing.nextDueDate ?? existing.dueDate ?? existing.createdAt);
+        const nextKey = budgetMonthKey(
+          updatedExpense.nextDueDate ?? updatedExpense.dueDate ?? updatedExpense.createdAt
+        );
+        next = ensureBudgetMonth(next, previousKey);
+        next = ensureBudgetMonth(next, nextKey);
+        for (const key of new Set([previousKey, nextKey])) {
+          next = recomputeBudgetMonth(next, key);
+        }
+        return next;
+      });
     },
     async deleteRecurringExpense(id) {
-      await persistAndSet((snapshot) => ({
-        ...snapshot,
-        recurringExpenses: snapshot.recurringExpenses.filter((expense) => expense.id !== id)
-      }));
+      await persistAndSet((snapshot) => {
+        const existing = snapshot.recurringExpenses.find((expense) => expense.id === id);
+        const next: FinancialSnapshot = {
+          ...snapshot,
+          recurringExpenses: snapshot.recurringExpenses.filter((expense) => expense.id !== id)
+        };
+        if (!existing) {
+          return next;
+        }
+        const key = budgetMonthKey(existing.nextDueDate ?? existing.dueDate ?? existing.createdAt);
+        let ensured = ensureBudgetMonth(next, key);
+        ensured = recomputeBudgetMonth(ensured, key);
+        return ensured;
+      });
     },
     async addManualAccount(payload) {
       const now = new Date().toISOString();
@@ -849,5 +1129,28 @@ export function useFinancialStore() {
     container.store.getState
   );
   const actions = useFinancialActions(container);
-  return useMemo<FinancialStoreContextValue>(() => ({ ...state, ...actions }), [actions, state]);
+  const selectors = useMemo<FinancialStoreSelectors>(() => {
+    const map = state.budgetMonths ?? {};
+    const budgetMonthsList = Object.values(map).sort((a, b) => a.month.localeCompare(b.month));
+    const allBudgetedPlannedExpenses = budgetMonthsList.flatMap((month) => month.plannedExpenses);
+    const budgetSummary = budgetMonthsList.reduce<BudgetMonthTotals>((acc, month) => ({
+      planned: acc.planned + month.totals.planned,
+      actual: acc.actual + month.totals.actual,
+      recurring: acc.recurring + month.totals.recurring,
+      rollover: acc.rollover + month.totals.rollover,
+      unassignedActuals: acc.unassignedActuals + month.totals.unassignedActuals,
+      variance: acc.variance + month.totals.variance
+    }), emptyTotals());
+    const getBudgetMonth = (monthKey: string) => map[monthKey];
+    return {
+      budgetMonthsList,
+      allBudgetedPlannedExpenses,
+      getBudgetMonth,
+      budgetSummary
+    } satisfies FinancialStoreSelectors;
+  }, [state.budgetMonths]);
+  return useMemo<FinancialStoreContextValue>(
+    () => ({ ...state, ...actions, ...selectors }),
+    [actions, selectors, state]
+  );
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -65,6 +65,24 @@ export interface PlannedExpenseItem extends Timestamped {
   notes?: string;
 }
 
+export interface BudgetMonthTotals {
+  planned: number;
+  actual: number;
+  recurring: number;
+  rollover: number;
+  unassignedActuals: number;
+  variance: number;
+}
+
+export interface BudgetMonth extends Timestamped {
+  month: string;
+  plannedExpenses: PlannedExpenseItem[];
+  recurringAllocations: RecurringExpense[];
+  rollovers: PlannedExpenseItem[];
+  unassignedActuals: Transaction[];
+  totals: BudgetMonthTotals;
+}
+
 export interface RecurringExpense extends Timestamped {
   id: string;
   name: string;
@@ -159,6 +177,7 @@ export interface FinancialSnapshot {
   transactions: Transaction[];
   monthlyIncomes: MonthlyIncome[];
   plannedExpenses: PlannedExpenseItem[];
+  budgetMonths: Record<string, BudgetMonth>;
   recurringExpenses: RecurringExpense[];
   goals: Goal[];
   insights: Insight[];

--- a/src/utils/snapshotMerge.ts
+++ b/src/utils/snapshotMerge.ts
@@ -1,5 +1,6 @@
 import type {
   Account,
+  BudgetMonth,
   Category,
   CategoryBudgets,
   ExportEvent,
@@ -24,6 +25,40 @@ const ensureTimestamps = <T extends Timestamped>(record: T, fallback: string): T
 
 const mapWithTimestamps = <T extends Timestamped>(items: T[] | undefined, fallback: string): T[] =>
   (items ?? []).map((item) => ensureTimestamps(item, fallback));
+
+const normaliseBudgetMonth = (month: BudgetMonth | undefined, key: string, fallback: string): BudgetMonth => {
+  const createdAt = month?.createdAt ?? fallback;
+  const updatedAt = month?.updatedAt ?? fallback;
+  return {
+    month: month?.month ?? key,
+    createdAt,
+    updatedAt,
+    plannedExpenses: mapWithTimestamps(month?.plannedExpenses, fallback),
+    recurringAllocations: mapWithTimestamps(month?.recurringAllocations, fallback),
+    rollovers: mapWithTimestamps(month?.rollovers, fallback),
+    unassignedActuals: mapWithTimestamps(month?.unassignedActuals, fallback),
+    totals: {
+      planned: month?.totals?.planned ?? 0,
+      actual: month?.totals?.actual ?? 0,
+      recurring: month?.totals?.recurring ?? 0,
+      rollover: month?.totals?.rollover ?? 0,
+      unassignedActuals: month?.totals?.unassignedActuals ?? 0,
+      variance: month?.totals?.variance ?? 0
+    }
+  } satisfies BudgetMonth;
+};
+
+const normaliseBudgetMonths = (
+  months: Record<string, BudgetMonth> | undefined,
+  fallback: string
+): Record<string, BudgetMonth> => {
+  const entries = Object.entries(months ?? {});
+  const normalised: Record<string, BudgetMonth> = {};
+  for (const [key, month] of entries) {
+    normalised[key] = normaliseBudgetMonth(month, key, fallback);
+  }
+  return normalised;
+};
 
 const normaliseBudgets = (budgets?: Category['budgets']): CategoryBudgets | undefined => {
   if (!budgets) return undefined;
@@ -72,6 +107,7 @@ export function normaliseSnapshot(snapshot?: Partial<FinancialSnapshot> | null):
     transactions: mapWithTimestamps<Transaction>(snapshot?.transactions, now),
     monthlyIncomes: mapWithTimestamps<MonthlyIncome>(snapshot?.monthlyIncomes, now),
     plannedExpenses: mapWithTimestamps<PlannedExpenseItem>(snapshot?.plannedExpenses, now),
+    budgetMonths: normaliseBudgetMonths(snapshot?.budgetMonths, now),
     recurringExpenses: mapWithTimestamps<RecurringExpense>(snapshot?.recurringExpenses, now),
     goals: mapWithTimestamps<Goal>(snapshot?.goals, now),
     insights: mapWithTimestamps<Insight>(snapshot?.insights, now),
@@ -107,6 +143,28 @@ export function mergeSnapshots(local: FinancialSnapshot, remote: FinancialSnapsh
     return local.profile.updatedAt >= remote.profile.updatedAt ? local.profile : remote.profile;
   })();
 
+  const mergeBudgetMonths = (
+    lhs: Record<string, BudgetMonth>,
+    rhs: Record<string, BudgetMonth>
+  ): Record<string, BudgetMonth> => {
+    const keys = new Set([...Object.keys(lhs), ...Object.keys(rhs)]);
+    const merged: Record<string, BudgetMonth> = {};
+    for (const key of keys) {
+      const left = lhs[key];
+      const right = rhs[key];
+      if (!left) {
+        merged[key] = right;
+        continue;
+      }
+      if (!right) {
+        merged[key] = left;
+        continue;
+      }
+      merged[key] = left.updatedAt >= right.updatedAt ? left : right;
+    }
+    return merged;
+  };
+
   return normaliseSnapshot({
     profile: profile ? { ...profile, currency: profile.currency ?? baseCurrency } : null,
     accounts: mergeCollections(local.accounts, remote.accounts),
@@ -114,6 +172,7 @@ export function mergeSnapshots(local: FinancialSnapshot, remote: FinancialSnapsh
     transactions: mergeCollections(local.transactions, remote.transactions),
     monthlyIncomes: mergeCollections(local.monthlyIncomes, remote.monthlyIncomes),
     plannedExpenses: mergeCollections(local.plannedExpenses, remote.plannedExpenses),
+    budgetMonths: mergeBudgetMonths(local.budgetMonths ?? {}, remote.budgetMonths ?? {}),
     recurringExpenses: mergeCollections(local.recurringExpenses, remote.recurringExpenses),
     goals: mergeCollections(local.goals, remote.goals),
     insights: mergeCollections(local.insights, remote.insights),

--- a/src/views/IncomeManagementView.tsx
+++ b/src/views/IncomeManagementView.tsx
@@ -108,7 +108,7 @@ export function IncomeManagementView() {
     monthlyIncomes,
     categories,
     transactions,
-    plannedExpenses,
+    allBudgetedPlannedExpenses,
     addMonthlyIncome,
     updateMonthlyIncome,
     deleteMonthlyIncome,
@@ -179,16 +179,16 @@ export function IncomeManagementView() {
   const categoryMonthOptions = useMemo(() => {
     const months = new Set<string>([selectedCategoryMonth, defaultMonth]);
     transactions.forEach((txn) => months.add(monthKey(txn.date)));
-    plannedExpenses.forEach((item) => months.add(monthKey(item.dueDate ?? item.createdAt)));
+    allBudgetedPlannedExpenses.forEach((item) => months.add(monthKey(item.dueDate ?? item.createdAt)));
     return Array.from(months).sort((a, b) => (a > b ? -1 : 1));
-  }, [transactions, plannedExpenses, selectedCategoryMonth, defaultMonth]);
+  }, [transactions, allBudgetedPlannedExpenses, selectedCategoryMonth, defaultMonth]);
 
   const categoryYearOptions = useMemo(() => {
     const years = new Set<string>([selectedCategoryYear, defaultYear]);
     transactions.forEach((txn) => years.add(yearKey(txn.date)));
-    plannedExpenses.forEach((item) => years.add(yearKey(item.dueDate ?? item.createdAt)));
+    allBudgetedPlannedExpenses.forEach((item) => years.add(yearKey(item.dueDate ?? item.createdAt)));
     return Array.from(years).sort((a, b) => (a > b ? -1 : 1));
-  }, [transactions, plannedExpenses, selectedCategoryYear, defaultYear]);
+  }, [transactions, allBudgetedPlannedExpenses, selectedCategoryYear, defaultYear]);
 
   const filteredIncomes = useMemo(
     () =>
@@ -256,12 +256,12 @@ export function IncomeManagementView() {
 
   const relevantPlannedExpenses = useMemo(
     () =>
-      plannedExpenses.filter((item) =>
+      allBudgetedPlannedExpenses.filter((item) =>
         categoryViewMode === 'monthly'
           ? monthKey(item.dueDate ?? item.createdAt) === selectedCategoryMonth
           : yearKey(item.dueDate ?? item.createdAt) === selectedCategoryYear
       ),
-    [plannedExpenses, categoryViewMode, selectedCategoryMonth, selectedCategoryYear]
+    [allBudgetedPlannedExpenses, categoryViewMode, selectedCategoryMonth, selectedCategoryYear]
   );
 
   const transactionMap = useMemo(() => {

--- a/src/views/InsightsView.tsx
+++ b/src/views/InsightsView.tsx
@@ -3,7 +3,14 @@ import { differenceInCalendarDays, format, isValid, parseISO } from 'date-fns';
 import { useFinancialStore } from '../store/FinancialStoreProvider';
 
 export function InsightsView() {
-  const { insights, transactions, categories, profile, recurringExpenses, plannedExpenses } = useFinancialStore();
+  const {
+    insights,
+    transactions,
+    categories,
+    profile,
+    recurringExpenses,
+    allBudgetedPlannedExpenses
+  } = useFinancialStore();
   const [ruleReduction, setRuleReduction] = useState(15);
 
   const currencyFormatter = useMemo(
@@ -121,7 +128,7 @@ export function InsightsView() {
   }, [recurringExpenses, currencyFormatter]);
 
   const plannedExpenseSummary = useMemo(() => {
-    const pendingExpenses = plannedExpenses.filter((expense) => expense.status === 'pending');
+    const pendingExpenses = allBudgetedPlannedExpenses.filter((expense) => expense.status === 'pending');
     const totalPending = pendingExpenses.reduce((sum, item) => sum + item.plannedAmount, 0);
 
     const nextExpense = pendingExpenses
@@ -146,7 +153,7 @@ export function InsightsView() {
           }
         : null
     };
-  }, [plannedExpenses]);
+  }, [allBudgetedPlannedExpenses]);
 
   const actionableTiles = useMemo(() => {
     return [

--- a/src/views/RecurringExpensesView.tsx
+++ b/src/views/RecurringExpensesView.tsx
@@ -14,7 +14,7 @@ export function RecurringExpensesView() {
     recurringExpenses,
     categories,
     transactions,
-    plannedExpenses,
+    allBudgetedPlannedExpenses,
     addRecurringExpense,
     updateRecurringExpense,
     deleteRecurringExpense
@@ -68,7 +68,7 @@ export function RecurringExpensesView() {
       frequency?: Frequency;
     }> = [];
 
-    plannedExpenses.forEach((item) => {
+    allBudgetedPlannedExpenses.forEach((item) => {
       if (!billCategoryIds.has(item.categoryId)) return;
       const due = new Date(item.dueDate).getTime();
       if (due >= startOfToday.getTime() && due <= horizon) {
@@ -100,7 +100,7 @@ export function RecurringExpensesView() {
 
     reminders.sort((a, b) => new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime());
     return reminders;
-  }, [plannedExpenses, recurringExpenses, billCategoryIds]);
+  }, [allBudgetedPlannedExpenses, recurringExpenses, billCategoryIds]);
 
   const reconciliation = useMemo(() => {
     return recurringExpenses.map((expense) => {


### PR DESCRIPTION
## Summary
- introduce budget month structures in the financial store, migrate legacy planned expenses, and recompute monthly aggregates
- persist budget month data through snapshots, ensure planner mutations stay scoped to their month, and expose selectors for monthly summaries
- update consumer views and smart budgeting logic to rely on the new monthly selectors instead of the flattened planned expenses list

## Testing
- npm test -- src/services/indexedDbService.test.ts *(fails: timeout when exercising encrypted persistence in vitest)*
- npm test -- --testTimeout=15000 src/services/indexedDbService.test.ts *(fails: timeout when exercising encrypted persistence in vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68e236646f80832c849c075a51910bb1