### PR TITLE
feat: normalise budget months in snapshots

### DIFF
--- a/src/services/indexedDbService.test.ts
+++ b/src/services/indexedDbService.test.ts
@@ -1,12 +1,18 @@
 import 'fake-indexeddb/auto';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { openDB } from 'idb';
 import { webcrypto } from 'node:crypto';
-import type { FinancialSnapshot } from '../types';
-import { decryptData, loadSnapshot, persistSnapshot } from './indexedDbService';
+import { createDefaultBudgetMonth, type FinancialSnapshot } from '../types';
+import { normaliseSnapshot } from '../utils/snapshotMerge';
+import {
+  decryptData,
+  loadSnapshot,
+  persistSnapshot,
+  resetIndexedDbConnectionForTests
+} from './indexedDbService';
 
 const DB_NAME = 'wealth-accelerator-db';
-const DB_VERSION = 4;
+const DB_VERSION = 5;
 
 const buildSnapshot = (timestamp: string): FinancialSnapshot => ({
   profile: {
@@ -58,6 +64,9 @@ const buildSnapshot = (timestamp: string): FinancialSnapshot => ({
     }
   ],
   plannedExpenses: [],
+  budgetMonths: {
+    '2024-01': createDefaultBudgetMonth('2024-01', 'INR')
+  },
   recurringExpenses: [],
   goals: [],
   insights: [
@@ -85,18 +94,19 @@ const buildSnapshot = (timestamp: string): FinancialSnapshot => ({
 let baseSnapshot: FinancialSnapshot;
 
 beforeEach(async () => {
-  vi.useFakeTimers();
-  vi.setSystemTime(new Date('2024-01-01T00:00:00.000Z'));
-  baseSnapshot = buildSnapshot(new Date().toISOString());
+  const timestamp = '2024-01-01T00:00:00.000Z';
+  baseSnapshot = buildSnapshot(timestamp);
   Object.defineProperty(globalThis, 'crypto', {
     configurable: true,
     value: webcrypto as Crypto
   });
-  await indexedDB.deleteDatabase(DB_NAME);
-});
-
-afterEach(() => {
-  vi.useRealTimers();
+  await resetIndexedDbConnectionForTests();
+  await new Promise<void>((resolve, reject) => {
+    const request = indexedDB.deleteDatabase(DB_NAME);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+    request.onblocked = () => resolve();
+  });
 });
 
 describe('indexedDbService encryption', () => {
@@ -110,15 +120,48 @@ describe('indexedDbService encryption', () => {
     expect(record?.payload).not.toContain('Checking');
 
     const decrypted = await decryptData(record?.payload ?? '');
-    expect(JSON.parse(decrypted)).toEqual(baseSnapshot);
+    expect(JSON.parse(decrypted)).toEqual(normaliseSnapshot(baseSnapshot));
+    db.close();
   });
 
   it('migrates legacy stores into an encrypted snapshot and clears plain text', async () => {
-    const db = await openDB(DB_NAME, DB_VERSION);
+    const db = await openDB(DB_NAME, DB_VERSION, {
+      upgrade(database) {
+        const ensureStore = (name: string) => {
+          if (!database.objectStoreNames.contains(name)) {
+            database.createObjectStore(name, { keyPath: 'id' });
+          }
+        };
+        ensureStore('accounts');
+        ensureStore('categories');
+        ensureStore('transactions');
+        ensureStore('monthlyIncomes');
+        ensureStore('plannedExpenses');
+        ensureStore('recurringExpenses');
+        ensureStore('goals');
+        ensureStore('insights');
+        ensureStore('wealthMetrics');
+        ensureStore('snapshots');
+      }
+    });
     await db.put('accounts', baseSnapshot.accounts[0]);
     await db.put('categories', baseSnapshot.categories[0]);
     await db.put('transactions', baseSnapshot.transactions[0]);
     await db.put('monthlyIncomes', baseSnapshot.monthlyIncomes[0]);
+    await db.put('plannedExpenses', {
+      id: 'planned-1',
+      name: 'New laptop',
+      plannedAmount: 75000,
+      actualAmount: 0,
+      categoryId: 'cat-2',
+      dueDate: '2024-01-20',
+      priority: 'high',
+      status: 'pending',
+      remainderAmount: null,
+      notes: 'Upgrade work setup',
+      createdAt: baseSnapshot.lastLocalChangeAt,
+      updatedAt: baseSnapshot.lastLocalChangeAt
+    });
     await db.put('wealthMetrics', { id: 'singleton', ...baseSnapshot.wealthMetrics });
 
     const snapshot = await loadSnapshot();
@@ -126,13 +169,26 @@ describe('indexedDbService encryption', () => {
     expect(snapshot?.accounts[0].name).toBe('Checking');
     expect(snapshot?.monthlyIncomes).toHaveLength(1);
     expect(snapshot?.profile).toBeNull();
+    expect(Object.keys(snapshot?.budgetMonths ?? {})).not.toHaveLength(0);
+    const january = (snapshot?.budgetMonths ?? {})['2024-01'];
+    expect(january?.plannedItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'planned-1', name: 'New laptop', plannedAmount: 75000 })
+      ])
+    );
+    expect(snapshot?.plannedExpenses).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: 'planned-1', name: 'New laptop' })])
+    );
 
     const legacyAccounts = await db.getAll('accounts');
     expect(legacyAccounts).toHaveLength(0);
     const legacyIncomes = await db.getAll('monthlyIncomes');
     expect(legacyIncomes).toHaveLength(0);
+    const legacyPlannedExpenses = await db.getAll('plannedExpenses');
+    expect(legacyPlannedExpenses).toHaveLength(0);
 
     const encryptedRecord = await db.get('snapshots', 'singleton');
     expect(encryptedRecord?.payload ?? '').not.toContain('Sample Bank');
+    db.close();
   });
 });

--- a/src/services/indexedDbService.ts
+++ b/src/services/indexedDbService.ts
@@ -11,10 +11,10 @@ import type {
   Transaction,
   WealthAcceleratorMetrics
 } from '../types';
-import { normaliseSnapshot } from '../utils/snapshotMerge';
+import { normaliseBudgetMonths, normaliseSnapshot } from '../utils/snapshotMerge';
 
 const DB_NAME = 'wealth-accelerator-db';
-const DB_VERSION = 4;
+const DB_VERSION = 5;
 const SNAPSHOT_STORE = 'snapshots';
 
 const LEGACY_STORES = [
@@ -38,6 +38,18 @@ interface SnapshotRecord {
 type LegacyStoreName = (typeof LEGACY_STORES)[number];
 
 let dbPromise: Promise<IDBPDatabase> | null = null;
+
+export async function resetIndexedDbConnectionForTests() {
+  if (dbPromise) {
+    try {
+      const db = await dbPromise;
+      db.close();
+    } catch (error) {
+      // ignore errors during cleanup in tests
+    }
+  }
+  dbPromise = null;
+}
 
 async function getDb() {
   if (!dbPromise) {
@@ -138,6 +150,10 @@ async function loadLegacySnapshot(): Promise<Partial<FinancialSnapshot> | null> 
     return null;
   }
 
+  const now = new Date().toISOString();
+  const baseCurrency = accounts.find((account) => account.currency)?.currency ?? 'INR';
+  const budgetMonths = normaliseBudgetMonths(undefined, plannedExpenses, baseCurrency, now);
+
   const metrics = wealthMetrics[0];
   return {
     profile: null,
@@ -146,6 +162,7 @@ async function loadLegacySnapshot(): Promise<Partial<FinancialSnapshot> | null> 
     transactions,
     monthlyIncomes,
     plannedExpenses,
+    budgetMonths,
     recurringExpenses,
     goals,
     insights,
@@ -154,13 +171,13 @@ async function loadLegacySnapshot(): Promise<Partial<FinancialSnapshot> | null> 
           capitalEfficiencyScore: metrics.capitalEfficiencyScore,
           opportunityCostAlerts: metrics.opportunityCostAlerts,
           insuranceGapAnalysis: metrics.insuranceGapAnalysis,
-          updatedAt: new Date().toISOString()
+          updatedAt: now
         }
       : undefined,
     smartExportRules: [],
     exportHistory: [],
     revision: 0,
-    lastLocalChangeAt: new Date().toISOString()
+    lastLocalChangeAt: now
   } satisfies Partial<FinancialSnapshot>;
 }
 

--- a/src/utils/snapshotMerge.ts
+++ b/src/utils/snapshotMerge.ts
@@ -1,7 +1,12 @@
 import type {
   Account,
+  BudgetActual,
+  BudgetMonth,
+  BudgetMonthTotals,
+  BudgetPlannedItem,
   Category,
   CategoryBudgets,
+  Currency,
   ExportEvent,
   FinancialSnapshot,
   Goal,
@@ -15,6 +20,7 @@ import type {
   Transaction,
   WealthAcceleratorMetrics
 } from '../types';
+import { createDefaultBudgetMonth } from '../types';
 
 const ensureTimestamps = <T extends Timestamped>(record: T, fallback: string): T => ({
   ...record,
@@ -24,6 +30,171 @@ const ensureTimestamps = <T extends Timestamped>(record: T, fallback: string): T
 
 const mapWithTimestamps = <T extends Timestamped>(items: T[] | undefined, fallback: string): T[] =>
   (items ?? []).map((item) => ensureTimestamps(item, fallback));
+
+const isValidNumber = (value: unknown): value is number => typeof value === 'number' && !Number.isNaN(value);
+
+const normaliseMonthTotals = (
+  totals: Partial<BudgetMonthTotals> | undefined,
+  plannedSum: number,
+  actualSum: number
+): BudgetMonthTotals => {
+  const planned = isValidNumber(totals?.planned) ? totals!.planned : plannedSum;
+  const actual = isValidNumber(totals?.actual) ? totals!.actual : actualSum;
+  const difference = isValidNumber(totals?.difference) ? totals!.difference : planned - actual;
+  const rolloverFromPrevious = isValidNumber(totals?.rolloverFromPrevious)
+    ? totals!.rolloverFromPrevious
+    : 0;
+  const rolloverToNext = isValidNumber(totals?.rolloverToNext) ? totals!.rolloverToNext : 0;
+
+  return {
+    planned,
+    actual,
+    difference,
+    rolloverFromPrevious,
+    rolloverToNext
+  } satisfies BudgetMonthTotals;
+};
+
+const normaliseBudgetMonthEntry = (
+  monthKey: string,
+  month: Partial<BudgetMonth> | undefined,
+  currency: Currency
+): BudgetMonth => {
+  const base = createDefaultBudgetMonth(monthKey, currency);
+
+  const plannedItems = Array.isArray(month?.plannedItems) ? month!.plannedItems : base.plannedItems;
+  const actuals = Array.isArray(month?.actuals) ? month!.actuals : base.actuals;
+  const unassignedActuals = Array.isArray(month?.unassignedActuals)
+    ? month!.unassignedActuals
+    : base.unassignedActuals;
+  const recurringAllocations = Array.isArray(month?.recurringAllocations)
+    ? month!.recurringAllocations
+    : base.recurringAllocations;
+  const adjustments = Array.isArray(month?.adjustments) ? month!.adjustments : base.adjustments;
+
+  const plannedSum = plannedItems.reduce(
+    (sum, item) => sum + (isValidNumber(item.plannedAmount) ? item.plannedAmount : 0),
+    0
+  );
+  const actualSum = actuals.reduce((sum, item) => sum + (isValidNumber(item.amount) ? item.amount : 0), 0);
+
+  return {
+    ...base,
+    ...month,
+    month: month?.month ?? monthKey,
+    currency: month?.currency ?? currency,
+    plannedItems,
+    actuals,
+    unassignedActuals,
+    recurringAllocations,
+    adjustments,
+    totals: normaliseMonthTotals(month?.totals, plannedSum, actualSum)
+  } satisfies BudgetMonth;
+};
+
+const mergeById = <T extends { id: string }>(local: T[], remote: T[]): T[] => {
+  const map = new Map<string, T>();
+  remote.forEach((item) => {
+    map.set(item.id, item);
+  });
+  local.forEach((item) => {
+    if (!map.has(item.id)) {
+      map.set(item.id, item);
+    }
+  });
+  return Array.from(map.values());
+};
+
+const deriveMonthKey = (value: string | undefined, fallback: string): string => {
+  if (!value) return fallback;
+  const key = value.slice(0, 7);
+  return /^\d{4}-\d{2}$/.test(key) ? key : fallback;
+};
+
+const createActualFromPlanned = (
+  expense: PlannedExpenseItem,
+  currency: Currency
+): BudgetActual | null => {
+  if (!isValidNumber(expense.actualAmount)) return null;
+  return {
+    id: `${expense.id}-actual`,
+    description: expense.name,
+    categoryId: expense.categoryId,
+    amount: expense.actualAmount,
+    currency,
+    occurredOn: expense.dueDate ?? undefined
+  } satisfies BudgetActual;
+};
+
+export const normaliseBudgetMonths = (
+  budgetMonths: Partial<Record<string, Partial<BudgetMonth>>> | BudgetMonth[] | undefined,
+  plannedExpenses: PlannedExpenseItem[] | undefined,
+  currency: Currency,
+  now: string
+): Record<string, BudgetMonth> => {
+  const monthMap = new Map<string, BudgetMonth>();
+
+  if (Array.isArray(budgetMonths)) {
+    budgetMonths.forEach((month) => {
+      if (!month) return;
+      const key = deriveMonthKey(month.month, now.slice(0, 7));
+      monthMap.set(key, normaliseBudgetMonthEntry(key, month, currency));
+    });
+  } else if (budgetMonths && typeof budgetMonths === 'object') {
+    Object.entries(budgetMonths).forEach(([key, month]) => {
+      if (!month) return;
+      const monthKey = deriveMonthKey(key || month.month, now.slice(0, 7));
+      monthMap.set(monthKey, normaliseBudgetMonthEntry(monthKey, month, currency));
+    });
+  }
+
+  if (monthMap.size === 0 && plannedExpenses && plannedExpenses.length > 0) {
+    const fallbackMonth = now.slice(0, 7);
+    plannedExpenses.forEach((expense) => {
+      const monthKey = deriveMonthKey(expense.dueDate ?? undefined, fallbackMonth);
+      const existing = monthMap.get(monthKey) ?? createDefaultBudgetMonth(monthKey, currency);
+
+      const plannedItem: BudgetPlannedItem = {
+        id: expense.id,
+        categoryId: expense.categoryId,
+        name: expense.name,
+        plannedAmount: expense.plannedAmount,
+        currency,
+        notes: expense.notes
+      } satisfies BudgetPlannedItem;
+
+      const plannedItems = [...existing.plannedItems.filter((item) => item.id !== plannedItem.id), plannedItem];
+
+      const actualEntry = createActualFromPlanned(expense, currency);
+      const actuals = actualEntry
+        ? [...existing.actuals.filter((item) => item.id !== actualEntry.id), actualEntry]
+        : existing.actuals;
+
+      const plannedSum = plannedItems.reduce((sum, item) => sum + item.plannedAmount, 0);
+      const actualSum = actuals.reduce((sum, item) => sum + item.amount, 0);
+
+      monthMap.set(monthKey, {
+        ...existing,
+        plannedItems,
+        actuals,
+        totals: {
+          planned: plannedSum,
+          actual: actualSum,
+          difference: plannedSum - actualSum,
+          rolloverFromPrevious: existing.totals.rolloverFromPrevious,
+          rolloverToNext: existing.totals.rolloverToNext
+        }
+      });
+    });
+  }
+
+  if (monthMap.size === 0) {
+    const defaultMonthKey = now.slice(0, 7);
+    monthMap.set(defaultMonthKey, createDefaultBudgetMonth(defaultMonthKey, currency));
+  }
+
+  return Object.fromEntries(Array.from(monthMap.entries()).sort((a, b) => a[0].localeCompare(b[0])));
+};
 
 const normaliseBudgets = (budgets?: Category['budgets']): CategoryBudgets | undefined => {
   if (!budgets) return undefined;
@@ -41,6 +212,7 @@ const normaliseBudgets = (budgets?: Category['budgets']): CategoryBudgets | unde
 
 export function normaliseSnapshot(snapshot?: Partial<FinancialSnapshot> | null): FinancialSnapshot {
   const now = new Date().toISOString();
+  const baseCurrency = snapshot?.profile?.currency ?? 'INR';
   const profile = snapshot?.profile ? ensureTimestamps<Profile>(snapshot.profile, now) : null;
 
   const wealthMetrics: WealthAcceleratorMetrics = snapshot?.wealthMetrics
@@ -65,13 +237,17 @@ export function normaliseSnapshot(snapshot?: Partial<FinancialSnapshot> | null):
     budgets: normaliseBudgets(category.budgets)
   }));
 
+  const plannedExpenses = mapWithTimestamps<PlannedExpenseItem>(snapshot?.plannedExpenses, now);
+  const budgetMonths = normaliseBudgetMonths(snapshot?.budgetMonths, plannedExpenses, baseCurrency, now);
+
   return {
     profile,
     accounts: mapWithTimestamps<Account>(snapshot?.accounts, now),
     categories,
     transactions: mapWithTimestamps<Transaction>(snapshot?.transactions, now),
     monthlyIncomes: mapWithTimestamps<MonthlyIncome>(snapshot?.monthlyIncomes, now),
-    plannedExpenses: mapWithTimestamps<PlannedExpenseItem>(snapshot?.plannedExpenses, now),
+    plannedExpenses,
+    budgetMonths,
     recurringExpenses: mapWithTimestamps<RecurringExpense>(snapshot?.recurringExpenses, now),
     goals: mapWithTimestamps<Goal>(snapshot?.goals, now),
     insights: mapWithTimestamps<Insight>(snapshot?.insights, now),
@@ -99,8 +275,57 @@ const mergeCollections = <T extends Timestamped & { id: string }>(local: T[], re
   return Array.from(merged.values()).sort((a, b) => a.updatedAt.localeCompare(b.updatedAt));
 };
 
+const mergeBudgetMonths = (
+  local: Record<string, BudgetMonth>,
+  remote: Record<string, BudgetMonth>,
+  currency: Currency,
+  now: string
+): Record<string, BudgetMonth> => {
+  const months = new Map<string, BudgetMonth>();
+  const allKeys = new Set([...Object.keys(local), ...Object.keys(remote)]);
+
+  allKeys.forEach((key) => {
+    const localMonth = local[key];
+    const remoteMonth = remote[key];
+    if (localMonth && !remoteMonth) {
+      months.set(key, normaliseBudgetMonthEntry(key, localMonth, localMonth.currency ?? currency));
+    } else if (!localMonth && remoteMonth) {
+      months.set(key, normaliseBudgetMonthEntry(key, remoteMonth, remoteMonth.currency ?? currency));
+    } else if (localMonth && remoteMonth) {
+      const merged: Partial<BudgetMonth> = {
+        ...remoteMonth,
+        plannedItems: mergeById(localMonth.plannedItems, remoteMonth.plannedItems),
+        actuals: mergeById(localMonth.actuals, remoteMonth.actuals),
+        unassignedActuals: mergeById(localMonth.unassignedActuals, remoteMonth.unassignedActuals),
+        recurringAllocations: mergeById(localMonth.recurringAllocations, remoteMonth.recurringAllocations),
+        adjustments: mergeById(localMonth.adjustments, remoteMonth.adjustments),
+        totals: {
+          planned: remoteMonth.totals.planned,
+          actual: remoteMonth.totals.actual,
+          difference:
+            remoteMonth.totals.difference ?? remoteMonth.totals.planned - remoteMonth.totals.actual,
+          rolloverFromPrevious: remoteMonth.totals.rolloverFromPrevious,
+          rolloverToNext: remoteMonth.totals.rolloverToNext
+        }
+      };
+      months.set(
+        key,
+        normaliseBudgetMonthEntry(key, merged, remoteMonth.currency ?? localMonth.currency ?? currency)
+      );
+    }
+  });
+
+  if (months.size === 0) {
+    const defaultMonthKey = now.slice(0, 7);
+    months.set(defaultMonthKey, createDefaultBudgetMonth(defaultMonthKey, currency));
+  }
+
+  return Object.fromEntries(Array.from(months.entries()).sort((a, b) => a[0].localeCompare(b[0])));
+};
+
 export function mergeSnapshots(local: FinancialSnapshot, remote: FinancialSnapshot): FinancialSnapshot {
   const baseCurrency = local.profile?.currency ?? remote.profile?.currency ?? 'INR';
+  const now = new Date().toISOString();
   const profile = (() => {
     if (!local.profile) return remote.profile ? normaliseSnapshot({ profile: remote.profile }).profile : null;
     if (!remote.profile) return local.profile;
@@ -114,6 +339,7 @@ export function mergeSnapshots(local: FinancialSnapshot, remote: FinancialSnapsh
     transactions: mergeCollections(local.transactions, remote.transactions),
     monthlyIncomes: mergeCollections(local.monthlyIncomes, remote.monthlyIncomes),
     plannedExpenses: mergeCollections(local.plannedExpenses, remote.plannedExpenses),
+    budgetMonths: mergeBudgetMonths(local.budgetMonths, remote.budgetMonths, baseCurrency, now),
     recurringExpenses: mergeCollections(local.recurringExpenses, remote.recurringExpenses),
     goals: mergeCollections(local.goals, remote.goals),
     insights: mergeCollections(local.insights, remote.insights),


### PR DESCRIPTION
## Summary
- normalise budget month data during snapshot import and merge, including planned expense migration
- bump the IndexedDB snapshot schema to version 5 and persist budget month payloads while migrating legacy data
- update IndexedDB service tests to cover the new schema defaults and cleaned legacy stores

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e23a4c15a8832c9fa5d3d2cb0e792f