### PR TITLE
Add comprehensive error boundaries across application modules

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,13 @@
+import type { ComponentType } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import { Route, Routes, useLocation } from 'react-router-dom';
 import { Button } from './components/atoms/Button';
+import { ErrorBoundary } from './components/atoms/ErrorBoundary';
+import type { ErrorBoundaryFallbackProps } from './components/atoms/ErrorBoundary';
 import { InitialSetupDialog } from './components/InitialSetupDialog';
 import { OfflineSyncStatus } from './components/OfflineSyncStatus';
 import { QuickExpenseCapture } from './components/QuickExpenseCapture';
+import { SectionErrorFallback } from './components/molecules/SectionErrorFallback';
 import { NavItem } from './components/molecules/NavItem';
 import { AppHeader } from './components/organisms/AppHeader/AppHeader';
 import { AppNavigation } from './components/organisms/AppNavigation/AppNavigation';
@@ -19,41 +23,66 @@ import { TrendAnalysisView } from './views/TrendAnalysisView';
 import { WealthAcceleratorView } from './views/WealthAcceleratorView';
 import { useFinancialStore } from './store/FinancialStoreProvider';
 
-const NAV_LINKS = [
-  { to: '/', label: 'CEO Dashboard', end: true },
-  { to: '/balance', label: 'Unified Balance Sheet' },
-  { to: '/trends', label: 'Trend Analysis' },
-  { to: '/budgeting', label: 'Smart Budgeting' },
-  { to: '/income', label: 'Income & Categories' },
-  { to: '/recurring', label: 'Recurring Expenses Hub' },
-  { to: '/goals', label: 'Goal Setting & Simulation' },
-  { to: '/insights', label: 'Actionable Insights' },
-  { to: '/accelerator', label: 'Wealth Accelerator Intelligence' }
-] as const;
+type RouteComponent = ComponentType<Record<string, never>>;
+
+type RouteConfig = {
+  path: string;
+  label: string;
+  Component: RouteComponent;
+  end?: boolean;
+};
+
+const ROUTES: RouteConfig[] = [
+  { path: '/', label: 'CEO Dashboard', Component: DashboardView, end: true },
+  { path: '/balance', label: 'Unified Balance Sheet', Component: BalanceSheetView },
+  { path: '/trends', label: 'Trend Analysis', Component: TrendAnalysisView },
+  { path: '/budgeting', label: 'Smart Budgeting', Component: SmartBudgetingView },
+  { path: '/income', label: 'Income & Categories', Component: IncomeManagementView },
+  { path: '/recurring', label: 'Recurring Expenses Hub', Component: RecurringExpensesView },
+  { path: '/goals', label: 'Goal Setting & Simulation', Component: GoalSimulatorView },
+  { path: '/insights', label: 'Actionable Insights', Component: InsightsView },
+  { path: '/accelerator', label: 'Wealth Accelerator Intelligence', Component: WealthAcceleratorView }
+];
+
+const NAV_LINKS = ROUTES.map(({ path, label, end }) => ({ to: path, label, end })) as const;
+
+const createSectionFallback =
+  (section: string) =>
+  ({ error, reset }: ErrorBoundaryFallbackProps) => (
+    <SectionErrorFallback section={section} error={error} onRetry={reset} />
+  );
 
 export default function App() {
   const [isNavOpen, setIsNavOpen] = useState(false);
   const location = useLocation();
   const { isInitialised, hasDismissedInitialSetup, requestInitialSetup } = useFinancialStore();
 
+  const headerFallback = useMemo(() => createSectionFallback('application header'), []);
+  const headerToolsFallback = useMemo(() => createSectionFallback('header tools'), []);
+  const navigationFallback = useMemo(() => createSectionFallback('navigation menu'), []);
+  const footerFallback = useMemo(() => createSectionFallback('quick actions'), []);
+  const workspaceFallback = useMemo(() => createSectionFallback('workspace'), []);
+
   useEffect(() => {
     setIsNavOpen(false);
   }, [location.pathname]);
 
   const headerRightSlot = (
-    <>
-      <OfflineSyncStatus />
-      {!isInitialised && hasDismissedInitialSetup ? (
-        <Button
-          type="button"
-          onClick={requestInitialSetup}
-          variant="ghost"
-          className="border border-accent/50 text-accent hover:bg-accent/10"
-        >
-          Resume ledger setup
-        </Button>
-      ) : null}
-    </>
+    <ErrorBoundary fallback={headerToolsFallback}>
+      <>
+        <OfflineSyncStatus />
+        {!isInitialised && hasDismissedInitialSetup ? (
+          <Button
+            type="button"
+            onClick={requestInitialSetup}
+            variant="ghost"
+            className="border border-accent/50 text-accent hover:bg-accent/10"
+          >
+            Resume ledger setup
+          </Button>
+        ) : null}
+      </>
+    </ErrorBoundary>
   );
 
   const navigationItems = NAV_LINKS.map((link) => (
@@ -63,33 +92,45 @@ export default function App() {
   return (
     <AppShell
       header={
-        <AppHeader
-          title="Wealth Accelerator"
-          subtitle="Offline-first financial intelligence engine for Indian CEOs & households"
-          isNavOpen={isNavOpen}
-          onToggleNav={() => setIsNavOpen((open) => !open)}
-          rightSlot={headerRightSlot}
-        />
+        <ErrorBoundary fallback={headerFallback}>
+          <AppHeader
+            title="Wealth Accelerator"
+            subtitle="Offline-first financial intelligence engine for Indian CEOs & households"
+            isNavOpen={isNavOpen}
+            onToggleNav={() => setIsNavOpen((open) => !open)}
+            rightSlot={headerRightSlot}
+          />
+        </ErrorBoundary>
       }
-      navigation={<AppNavigation isNavOpen={isNavOpen} items={navigationItems} />}
+      navigation={
+        <ErrorBoundary fallback={navigationFallback}>
+          <AppNavigation isNavOpen={isNavOpen} items={navigationItems} />
+        </ErrorBoundary>
+      }
       footer={
-        <>
-          <QuickExpenseCapture />
-          <InitialSetupDialog />
-        </>
+        <ErrorBoundary fallback={footerFallback}>
+          <>
+            <QuickExpenseCapture />
+            <InitialSetupDialog />
+          </>
+        </ErrorBoundary>
       }
     >
-      <Routes>
-        <Route path="/" element={<DashboardView />} />
-        <Route path="/balance" element={<BalanceSheetView />} />
-        <Route path="/trends" element={<TrendAnalysisView />} />
-        <Route path="/budgeting" element={<SmartBudgetingView />} />
-        <Route path="/income" element={<IncomeManagementView />} />
-        <Route path="/recurring" element={<RecurringExpensesView />} />
-        <Route path="/goals" element={<GoalSimulatorView />} />
-        <Route path="/insights" element={<InsightsView />} />
-        <Route path="/accelerator" element={<WealthAcceleratorView />} />
-      </Routes>
+      <ErrorBoundary key={location.pathname} fallback={workspaceFallback}>
+        <Routes>
+          {ROUTES.map(({ path, Component, label }) => (
+            <Route
+              key={path}
+              path={path}
+              element={
+                <ErrorBoundary fallback={createSectionFallback(label)}>
+                  <Component />
+                </ErrorBoundary>
+              }
+            />
+          ))}
+        </Routes>
+      </ErrorBoundary>
     </AppShell>
   );
 }

--- a/src/components/atoms/ErrorBoundary.tsx
+++ b/src/components/atoms/ErrorBoundary.tsx
@@ -1,0 +1,86 @@
+import { Component } from 'react';
+import type { ErrorInfo, ReactNode } from 'react';
+import { Button } from './Button';
+
+type ErrorBoundaryFallback = ReactNode | ErrorBoundaryFallbackRender;
+
+export type ErrorBoundaryFallbackRender = (props: ErrorBoundaryFallbackProps) => ReactNode;
+
+export interface ErrorBoundaryFallbackProps {
+  error: Error;
+  reset: () => void;
+}
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: ErrorBoundaryFallback;
+  onError?: (error: Error, info: ErrorInfo) => void;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = {
+    hasError: false,
+    error: null
+  };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    const { onError } = this.props;
+
+    if (typeof onError === 'function') {
+      onError(error, info);
+    }
+
+    if (import.meta.env.DEV) {
+      console.error('ErrorBoundary captured an error', error, info);
+    }
+  }
+
+  private resetBoundary = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    const { hasError, error } = this.state;
+    const { children, fallback } = this.props;
+
+    if (hasError) {
+      const safeError = error ?? new Error('Unknown error');
+
+      if (typeof fallback === 'function') {
+        return fallback({ error: safeError, reset: this.resetBoundary });
+      }
+
+      if (fallback) {
+        return fallback;
+      }
+
+      return (
+        <div className="flex flex-col items-center justify-center gap-4 rounded-lg border border-red-500/40 bg-red-500/10 p-6 text-center text-red-100">
+          <div>
+            <p className="text-lg font-semibold">Something went wrong.</p>
+            <p className="text-sm text-red-100/80">Try the action again or refresh the page.</p>
+          </div>
+          {import.meta.env.DEV ? (
+            <pre className="max-w-full overflow-auto rounded bg-slate-950/70 p-4 text-left text-xs text-red-200">
+              {safeError.message}
+            </pre>
+          ) : null}
+          <Button type="button" variant="secondary" onClick={this.resetBoundary}>
+            Try again
+          </Button>
+        </div>
+      );
+    }
+
+    return children;
+  }
+}

--- a/src/components/molecules/SectionErrorFallback.tsx
+++ b/src/components/molecules/SectionErrorFallback.tsx
@@ -1,0 +1,62 @@
+import type { ReactNode } from 'react';
+import { Button } from '../atoms/Button';
+
+interface SectionErrorFallbackProps {
+  section: string;
+  error: Error;
+  onRetry: () => void;
+  layout?: 'inline' | 'full';
+  actionLabel?: string;
+  additionalContent?: ReactNode;
+}
+
+const isDevEnvironment = import.meta.env.DEV;
+
+export function SectionErrorFallback({
+  section,
+  error,
+  onRetry,
+  layout = 'inline',
+  actionLabel = 'Try again',
+  additionalContent
+}: SectionErrorFallbackProps) {
+  if (layout === 'full') {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center gap-6 bg-slate-950 p-6 text-center text-slate-100">
+        <div className="space-y-2">
+          <h1 className="text-2xl font-semibold">We hit a snag.</h1>
+          <p className="max-w-xl text-sm text-slate-400">
+            The {section} is currently unavailable. Please try again in a moment or reload the page.
+          </p>
+        </div>
+        {isDevEnvironment ? (
+          <pre className="max-w-xl overflow-auto rounded-lg border border-slate-800 bg-slate-900 p-4 text-left text-xs text-red-200">
+            {error.message}
+          </pre>
+        ) : null}
+        <Button type="button" variant="secondary" onClick={onRetry}>
+          {actionLabel}
+        </Button>
+        {additionalContent}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-100">
+      <div className="space-y-1">
+        <p className="font-semibold">{section} is temporarily unavailable.</p>
+        <p className="text-xs text-red-100/80">Try the action again. If the problem persists, reload the page.</p>
+      </div>
+      {isDevEnvironment ? (
+        <pre className="max-h-32 overflow-auto rounded bg-slate-950/70 p-3 text-xs text-red-200">{error.message}</pre>
+      ) : null}
+      <div>
+        <Button type="button" variant="secondary" onClick={onRetry}>
+          {actionLabel}
+        </Button>
+      </div>
+      {additionalContent}
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,10 +2,23 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
+import { ErrorBoundary } from './components/atoms/ErrorBoundary';
+import type { ErrorBoundaryFallbackProps } from './components/atoms/ErrorBoundary';
+import { SectionErrorFallback } from './components/molecules/SectionErrorFallback';
 import './styles/index.css';
 import { FinancialStoreProvider } from './store/FinancialStoreProvider';
 import { registerServiceWorker } from './serviceWorkerRegistration';
 import { setupWebCrypto } from './utils/setupWebCrypto';
+
+const applicationFallback = ({ error }: ErrorBoundaryFallbackProps) => (
+  <SectionErrorFallback
+    section="application"
+    error={error}
+    layout="full"
+    actionLabel="Reload app"
+    onRetry={() => window.location.reload()}
+  />
+);
 
 setupWebCrypto();
 
@@ -17,9 +30,11 @@ if (!rootElement) {
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
     <BrowserRouter>
-      <FinancialStoreProvider>
-        <App />
-      </FinancialStoreProvider>
+      <ErrorBoundary fallback={applicationFallback}>
+        <FinancialStoreProvider>
+          <App />
+        </FinancialStoreProvider>
+      </ErrorBoundary>
     </BrowserRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- create a reusable ErrorBoundary component and shared section-specific fallback UI
- wrap app shell sections and individual routes with error boundaries to keep modules isolated
- guard the root render tree with a full-screen fallback for unrecoverable failures

## Testing
- npm run build
- npm run lint *(fails: ESLint configuration missing in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68e241dfa4ac832cba7256181d609180