### PR TITLE
Align smart budgeting summary cards

### DIFF
--- a/src/features/smart-budgeting/organisms/CategoryInspector.tsx
+++ b/src/features/smart-budgeting/organisms/CategoryInspector.tsx
@@ -15,144 +15,146 @@ export function CategoryInspector({ inspector, utils }: CategoryInspectorProps) 
     handleFocusDetail
   } = inspector;
 
-  if (!focusedCategory) {
-    return (
-      <aside className="rounded-lg border border-slate-800 bg-slate-950/80 p-3 text-xs text-slate-500">
-        Choose a category on the left to review overspending, upcoming work, and progress.
-      </aside>
-    );
-  }
-
   return (
-    <aside className="w-full space-y-4 rounded-2xl border border-slate-800/60 bg-slate-950/60 p-4 text-xs text-slate-300 lg:max-w-sm">
+    <aside className="flex h-full flex-col rounded-2xl border border-slate-800/60 bg-slate-950/60 p-4 text-xs text-slate-300">
       <header>
         <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Category insights</p>
-        <h2 className="mt-1 text-lg font-semibold text-slate-100">{focusedCategory.name}</h2>
+        <h2 className="mt-1 text-lg font-semibold text-slate-100">
+          {focusedCategory ? focusedCategory.name : 'Select a category'}
+        </h2>
       </header>
 
-      <section>
-        <h5 className="text-xs font-semibold uppercase tracking-wide text-slate-400">Overspending risks</h5>
-        {inspectorOverspendingItems.length > 0 ? (
-          <ul className="mt-2 space-y-2">
-            {inspectorOverspendingItems.map((detail) => (
-              <li key={detail.item.id} className="rounded-lg border border-danger/40 bg-danger/5 px-3 py-2 text-xs text-danger">
-                <div className="flex items-center justify-between gap-2">
-                  <span className="font-semibold text-danger/90">{detail.item.name}</span>
-                  <span>{utils.formatCurrency(detail.variance)}</span>
-                </div>
-                <button
-                  type="button"
-                  onClick={() => handleFocusDetail(detail)}
-                  className="mt-1 text-[10px] font-semibold text-danger hover:underline"
-                >
-                  Investigate
-                </button>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p className="mt-2 text-xs text-slate-500">No overspending yet. Keep tracking!</p>
-        )}
-      </section>
+      {focusedCategory ? (
+        <div className="mt-4 flex-1 space-y-4 overflow-y-auto pr-1">
+          <section>
+            <h5 className="text-xs font-semibold uppercase tracking-wide text-slate-400">Overspending risks</h5>
+            {inspectorOverspendingItems.length > 0 ? (
+              <ul className="mt-2 space-y-2">
+                {inspectorOverspendingItems.map((detail) => (
+                  <li key={detail.item.id} className="rounded-lg border border-danger/40 bg-danger/5 px-3 py-2 text-xs text-danger">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="font-semibold text-danger/90">{detail.item.name}</span>
+                      <span>{utils.formatCurrency(detail.variance)}</span>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => handleFocusDetail(detail)}
+                      className="mt-1 text-[10px] font-semibold text-danger hover:underline"
+                    >
+                      Investigate
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="mt-2 text-xs text-slate-500">No overspending yet. Keep tracking!</p>
+            )}
+          </section>
 
-      <section>
-        <h5 className="text-xs font-semibold uppercase tracking-wide text-slate-400">Upcoming items</h5>
-        {inspectorUpcomingItems.length > 0 ? (
-          <ul className="mt-2 space-y-2">
-            {inspectorUpcomingItems.map((detail) => (
-              <li key={detail.item.id} className="rounded-lg border border-slate-800 bg-slate-950/80 px-3 py-2 text-xs text-slate-300">
-                <div className="flex items-center justify-between gap-2">
-                  <span className="font-semibold text-slate-100">{detail.item.name}</span>
-                  <span>
-                    {detail.item.dueDate
-                      ? new Date(detail.item.dueDate).toLocaleDateString('en-IN', {
-                          month: 'short',
-                          day: 'numeric'
-                        })
-                      : 'No due date'}
-                  </span>
-                </div>
-                <div className="mt-1 flex items-center justify-between gap-2">
-                  <span>{utils.formatCurrency(detail.item.plannedAmount)}</span>
-                  <button
-                    type="button"
-                    onClick={() => handleFocusDetail(detail)}
-                    className="font-semibold text-accent hover:underline"
-                  >
-                    Edit plan
-                  </button>
-                </div>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p className="mt-2 text-xs text-slate-500">No upcoming items in this category.</p>
-        )}
-      </section>
+          <section>
+            <h5 className="text-xs font-semibold uppercase tracking-wide text-slate-400">Upcoming items</h5>
+            {inspectorUpcomingItems.length > 0 ? (
+              <ul className="mt-2 space-y-2">
+                {inspectorUpcomingItems.map((detail) => (
+                  <li key={detail.item.id} className="rounded-lg border border-slate-800 bg-slate-950/80 px-3 py-2 text-xs text-slate-300">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="font-semibold text-slate-100">{detail.item.name}</span>
+                      <span>
+                        {detail.item.dueDate
+                          ? new Date(detail.item.dueDate).toLocaleDateString('en-IN', {
+                              month: 'short',
+                              day: 'numeric'
+                            })
+                          : 'No due date'}
+                      </span>
+                    </div>
+                    <div className="mt-1 flex items-center justify-between gap-2">
+                      <span>{utils.formatCurrency(detail.item.plannedAmount)}</span>
+                      <button
+                        type="button"
+                        onClick={() => handleFocusDetail(detail)}
+                        className="font-semibold text-accent hover:underline"
+                      >
+                        Edit plan
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="mt-2 text-xs text-slate-500">No upcoming items in this category.</p>
+            )}
+          </section>
 
-      <section>
-        <h5 className="text-xs font-semibold uppercase tracking-wide text-slate-400">In-progress items</h5>
-        {inspectorInProgressItems.length > 0 ? (
-          <ul className="mt-2 space-y-2">
-            {inspectorInProgressItems.map((detail) => (
-              <li key={detail.item.id} className="rounded-lg border border-slate-800 bg-slate-950/80 px-3 py-2 text-xs text-slate-300">
-                <div className="flex items-center justify-between gap-2">
-                  <span className="font-semibold text-slate-100">{detail.item.name}</span>
-                  {utils.statusBadge(detail.item.status)}
-                </div>
-                <div className="mt-1 flex items-center justify-between gap-2 text-[11px] text-slate-400">
-                  <span>
-                    Due{' '}
-                    {detail.item.dueDate
-                      ? new Date(detail.item.dueDate).toLocaleDateString('en-IN', {
-                          month: 'short',
-                          day: 'numeric'
-                        })
-                      : '—'}
-                  </span>
-                  <button
-                    type="button"
-                    onClick={() => handleFocusDetail(detail)}
-                    className="font-semibold text-accent hover:underline"
-                  >
-                    Update
-                  </button>
-                </div>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p className="mt-2 text-xs text-slate-500">No items currently in progress.</p>
-        )}
-      </section>
+          <section>
+            <h5 className="text-xs font-semibold uppercase tracking-wide text-slate-400">In-progress items</h5>
+            {inspectorInProgressItems.length > 0 ? (
+              <ul className="mt-2 space-y-2">
+                {inspectorInProgressItems.map((detail) => (
+                  <li key={detail.item.id} className="rounded-lg border border-slate-800 bg-slate-950/80 px-3 py-2 text-xs text-slate-300">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="font-semibold text-slate-100">{detail.item.name}</span>
+                      {utils.statusBadge(detail.item.status)}
+                    </div>
+                    <div className="mt-1 flex items-center justify-between gap-2 text-[11px] text-slate-400">
+                      <span>
+                        Due{' '}
+                        {detail.item.dueDate
+                          ? new Date(detail.item.dueDate).toLocaleDateString('en-IN', {
+                              month: 'short',
+                              day: 'numeric'
+                            })
+                          : '—'}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => handleFocusDetail(detail)}
+                        className="font-semibold text-accent hover:underline"
+                      >
+                        Update
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="mt-2 text-xs text-slate-500">No items currently in progress.</p>
+            )}
+          </section>
 
-      <section>
-        <h5 className="text-xs font-semibold uppercase tracking-wide text-slate-400">Completed items</h5>
-        {inspectorCompletedItems.length > 0 ? (
-          <ul className="mt-2 space-y-2">
-            {inspectorCompletedItems.map((detail) => (
-              <li key={detail.item.id} className="rounded-lg border border-slate-800 bg-slate-950/80 px-3 py-2 text-xs text-slate-300">
-                <div className="flex items-center justify-between gap-2">
-                  <span className="font-semibold text-slate-100">{detail.item.name}</span>
-                  <span className="font-semibold text-success">{utils.formatCurrency(detail.actual)}</span>
-                </div>
-                <div className="mt-1 flex items-center justify-between gap-2 text-[11px] text-slate-400">
-                  <span>Planned {utils.formatCurrency(detail.item.plannedAmount)}</span>
-                  <button
-                    type="button"
-                    onClick={() => handleFocusDetail(detail)}
-                    className="font-semibold text-accent hover:underline"
-                  >
-                    Review
-                  </button>
-                </div>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p className="mt-2 text-xs text-slate-500">No completed items recorded yet.</p>
-        )}
-      </section>
+          <section>
+            <h5 className="text-xs font-semibold uppercase tracking-wide text-slate-400">Completed items</h5>
+            {inspectorCompletedItems.length > 0 ? (
+              <ul className="mt-2 space-y-2">
+                {inspectorCompletedItems.map((detail) => (
+                  <li key={detail.item.id} className="rounded-lg border border-slate-800 bg-slate-950/80 px-3 py-2 text-xs text-slate-300">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="font-semibold text-slate-100">{detail.item.name}</span>
+                      <span className="font-semibold text-success">{utils.formatCurrency(detail.actual)}</span>
+                    </div>
+                    <div className="mt-1 flex items-center justify-between gap-2 text-[11px] text-slate-400">
+                      <span>Planned {utils.formatCurrency(detail.item.plannedAmount)}</span>
+                      <button
+                        type="button"
+                        onClick={() => handleFocusDetail(detail)}
+                        className="font-semibold text-accent hover:underline"
+                      >
+                        Review
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="mt-2 text-xs text-slate-500">No completed items recorded yet.</p>
+            )}
+          </section>
+        </div>
+      ) : (
+        <p className="mt-4 text-xs text-slate-500">
+          Choose a category on the left to review overspending, upcoming work, and progress.
+        </p>
+      )}
     </aside>
   );
 }

--- a/src/features/smart-budgeting/organisms/SummaryGrid.tsx
+++ b/src/features/smart-budgeting/organisms/SummaryGrid.tsx
@@ -34,8 +34,8 @@ export function SummaryGrid({ overview, categories, utils }: SummaryGridProps) {
   } = categories;
 
   return (
-    <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-      <article className="rounded-xl border border-slate-800 bg-slate-950/60 p-4">
+    <>
+      <article className="flex h-full flex-col rounded-xl border border-slate-800 bg-slate-950/60 p-4">
         <div className="flex items-start justify-between gap-3">
           <div>
             <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">{summaryPeriodLabel} overview</p>
@@ -62,7 +62,7 @@ export function SummaryGrid({ overview, categories, utils }: SummaryGridProps) {
         </div>
       </article>
 
-      <article className="rounded-xl border border-slate-800 bg-slate-950/60 p-4">
+      <article className="flex h-full flex-col rounded-xl border border-slate-800 bg-slate-950/60 p-4">
         <div className="flex items-start justify-between gap-3">
           <div>
             <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Summary scope</p>
@@ -114,10 +114,10 @@ export function SummaryGrid({ overview, categories, utils }: SummaryGridProps) {
         )}
       </article>
 
-      <article className="rounded-xl border border-slate-800 bg-slate-950/60 p-4">
+      <article className="flex h-full flex-col rounded-xl border border-slate-800 bg-slate-950/60 p-4">
         <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Overspending hotspots</p>
         {overspendingCategories.length > 0 ? (
-          <ul className="mt-3 space-y-2 text-xs">
+          <ul className="mt-3 flex-1 space-y-2 overflow-y-auto pr-1 text-xs">
             {overspendingCategories.map(({ category, summary }) => (
               <li key={category.id} className="rounded-lg border border-danger/40 bg-danger/5 px-3 py-2">
                 <div className="flex items-center justify-between gap-2">
@@ -146,7 +146,6 @@ export function SummaryGrid({ overview, categories, utils }: SummaryGridProps) {
           <p className="mt-3 text-xs text-slate-500">No overspending recorded in this {summaryPeriodDescriptor}.</p>
         )}
       </article>
-
-    </section>
+    </>
   );
 }

--- a/src/views/SmartBudgetingView.tsx
+++ b/src/views/SmartBudgetingView.tsx
@@ -21,9 +21,10 @@ export function SmartBudgetingView() {
         onCollapseAll={categories.collapseAllCategories}
       />
 
-      <SummaryGrid overview={overview} categories={categories} utils={utils} />
-
-      <CategoryInspector inspector={inspector} utils={utils} />
+      <section className="grid gap-4 lg:grid-cols-2 xl:grid-cols-4">
+        <SummaryGrid overview={overview} categories={categories} utils={utils} />
+        <CategoryInspector inspector={inspector} utils={utils} />
+      </section>
 
       <NavigatorFilters categories={categories} />
 


### PR DESCRIPTION
## Summary
- align the summary cards in the smart budgeting dashboard by rendering them within a single responsive grid
- update the overspending and inspector cards so their content scrolls within a consistent height container
- adjust the category inspector layout to keep its empty state and content within the shared card styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e244ad6cb8832c8551cfa9bce1a640