### PR TITLE
Use icon buttons for summary expand controls

### DIFF
--- a/src/features/smart-budgeting/organisms/SummaryHeaderControls.tsx
+++ b/src/features/smart-budgeting/organisms/SummaryHeaderControls.tsx
@@ -102,16 +102,40 @@ export function SummaryHeaderControls({ period, onOpenDialog, onExpandAll, onCol
           <button
             type="button"
             onClick={onExpandAll}
-            className="rounded-lg border border-slate-700 px-3 py-2 text-xs font-semibold text-slate-300 transition hover:border-slate-500"
+            aria-label="Expand all"
+            className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-slate-700 text-slate-300 transition hover:border-slate-500 hover:text-accent"
           >
-            Expand all
+            <svg
+              aria-hidden="true"
+              className="h-4 w-4"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M12 5v14M5 12h14" />
+            </svg>
           </button>
           <button
             type="button"
             onClick={onCollapseAll}
-            className="rounded-lg border border-slate-700 px-3 py-2 text-xs font-semibold text-slate-300 transition hover:border-slate-500"
+            aria-label="Collapse all"
+            className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-slate-700 text-slate-300 transition hover:border-slate-500 hover:text-accent"
           >
-            Collapse all
+            <svg
+              aria-hidden="true"
+              className="h-4 w-4"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M5 12h14" />
+            </svg>
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- replace the smart budgeting expand/collapse text buttons with icon-only controls while keeping accessible labels

## Testing
- npm run lint *(fails: ESLint configuration file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e249af53b8832c83e57a082dc8f49c