### PR TITLE
Refine summary period controls

### DIFF
--- a/src/features/smart-budgeting/organisms/SummaryHeaderControls.tsx
+++ b/src/features/smart-budgeting/organisms/SummaryHeaderControls.tsx
@@ -31,6 +31,8 @@ export function SummaryHeaderControls({ period, table, onOpenDialog, onExpandAll
     actions: 'Actions'
   } as const;
   const columnMenuId = useId();
+  const monthInputId = useId();
+  const yearInputId = useId();
   const monthInputRef = useRef<HTMLInputElement>(null);
   const yearInputRef = useRef<HTMLInputElement>(null);
 
@@ -38,11 +40,18 @@ export function SummaryHeaderControls({ period, table, onOpenDialog, onExpandAll
     if (viewMode !== 'monthly') {
       handleViewModeChange('monthly');
     }
-    if (typeof monthInputRef.current?.showPicker === 'function') {
-      monthInputRef.current.showPicker();
+
+    const monthInput = monthInputRef.current;
+    if (!monthInput) {
       return;
     }
-    monthInputRef.current?.focus();
+
+    if (typeof monthInput.showPicker === 'function') {
+      monthInput.showPicker();
+      return;
+    }
+
+    monthInput.focus();
   };
 
   const focusYearInput = () => {
@@ -94,54 +103,86 @@ export function SummaryHeaderControls({ period, table, onOpenDialog, onExpandAll
       </div>
 
       <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-        <div className="flex flex-wrap items-center gap-2 rounded-lg border border-slate-700 bg-slate-950/70 px-3 py-2 text-sm text-slate-200">
-          <button
-            type="button"
-            onClick={goToPreviousPeriod}
-            className="rounded-md border border-slate-700 px-2 py-1 text-xs font-semibold text-slate-300 transition hover:border-slate-500 hover:text-accent"
-            aria-label="Previous period"
-          >
-            ‹
-          </button>
-          <button
-            type="button"
-            onClick={handleOpenPeriodPicker}
-            className="rounded-md px-3 py-1 text-sm font-semibold text-slate-100 transition hover:bg-slate-800/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/70"
-            aria-label={viewMode === 'monthly' ? 'Select month' : 'Select year'}
-          >
-            {periodLabel}
-          </button>
-          <button
-            type="button"
-            onClick={goToNextPeriod}
-            className="rounded-md border border-slate-700 px-2 py-1 text-xs font-semibold text-slate-300 transition hover:border-slate-500 hover:text-accent"
-            aria-label="Next period"
-          >
-            ›
-          </button>
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2 rounded-lg border border-slate-700 bg-slate-950/70 px-2 py-2 text-sm text-slate-200">
+            <button
+              type="button"
+              onClick={goToPreviousPeriod}
+              className="rounded-md border border-slate-700 px-2 py-1 text-xs font-semibold text-slate-300 transition hover:border-slate-500 hover:text-accent"
+              aria-label="Previous period"
+            >
+              ‹
+            </button>
+            <div className="flex items-center gap-2 rounded-md border border-slate-800/70 bg-slate-900/40 px-2 py-1">
+              {viewMode === 'monthly' ? (
+                <>
+                  <input
+                    id={monthInputId}
+                    type="month"
+                    value={selectedMonth}
+                    onChange={(event) => handleMonthInputChange(event.target.value)}
+                    ref={monthInputRef}
+                    className="sr-only"
+                    aria-label="Select month"
+                  />
+                  <button
+                    type="button"
+                    onClick={openMonthPicker}
+                    className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-slate-700/70 text-slate-300 transition hover:border-slate-500 hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/70"
+                    aria-controls={monthInputId}
+                    aria-label="Open month picker"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="h-4 w-4"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
+                      <rect x="3" y="4" width="18" height="18" rx="2" />
+                      <path d="M16 2v4M8 2v4M3 10h18" />
+                    </svg>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleOpenPeriodPicker}
+                    className="rounded-md px-3 py-1 text-sm font-semibold text-slate-100 transition hover:bg-slate-800/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/70"
+                    aria-label="Select month"
+                  >
+                    {periodLabel}
+                  </button>
+                </>
+              ) : (
+                <label htmlFor={yearInputId} className="flex items-center gap-2 text-slate-200">
+                  <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">Year</span>
+                  <input
+                    id={yearInputId}
+                    type="text"
+                    inputMode="numeric"
+                    pattern="[0-9]*"
+                    maxLength={4}
+                    value={selectedYear}
+                    onChange={(event) => handleYearInputChange(event.target.value)}
+                    ref={yearInputRef}
+                    className="w-20 rounded-md border border-slate-700/70 bg-slate-950/70 px-3 py-1 text-sm font-semibold text-slate-100 focus:border-accent focus:outline-none"
+                    aria-label="Select year"
+                  />
+                </label>
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={goToNextPeriod}
+              className="rounded-md border border-slate-700 px-2 py-1 text-xs font-semibold text-slate-300 transition hover:border-slate-500 hover:text-accent"
+              aria-label="Next period"
+            >
+              ›
+            </button>
+          </div>
         </div>
-        {viewMode === 'monthly' ? (
-          <input
-            type="month"
-            value={selectedMonth}
-            onChange={(event) => handleMonthInputChange(event.target.value)}
-            ref={monthInputRef}
-            className="rounded-lg border border-slate-700 bg-slate-950/70 px-3 py-2 text-sm text-slate-100 focus:border-accent focus:outline-none"
-            aria-label="Select month"
-          />
-        ) : (
-          <input
-            type="text"
-            inputMode="numeric"
-            pattern="[0-9]*"
-            maxLength={4}
-            value={selectedYear}
-            onChange={(event) => handleYearInputChange(event.target.value)}
-            ref={yearInputRef}
-            className="w-24 rounded-lg border border-slate-700 bg-slate-950/70 px-3 py-2 text-sm text-slate-100 focus:border-accent focus:outline-none"
-            aria-label="Select year"
-          />
-        )}
         <div className="flex flex-wrap items-center gap-2">
           <button
             type="button"


### PR DESCRIPTION
## Summary
- combine the period navigation with embedded month/year selectors, including a dedicated calendar icon trigger for the month picker
- harden the month picker opener so it falls back to focusing the hidden input when the native picker is unavailable

## Testing
- npm run lint *(fails: ESLint configuration file is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68e2505cf668832c9a6313b656280f85