### PR TITLE
Ensure ledger snapshot removes deleted planned items

### DIFF
--- a/src/store/FinancialStoreProvider.tsx
+++ b/src/store/FinancialStoreProvider.tsx
@@ -214,6 +214,43 @@ const toBudgetPlannedItem = (
   notes: item.notes
 });
 
+const DEFAULT_CURRENCY: Currency = 'INR';
+
+const resolveMonthCurrency = (
+  snapshot: FinancialSnapshot,
+  month: BudgetMonth | undefined
+): Currency =>
+  ((month as unknown as { currency?: Currency })?.currency) ??
+  snapshot.profile?.currency ??
+  DEFAULT_CURRENCY;
+
+const syncPlannedEntriesForMonth = (
+  snapshot: FinancialSnapshot,
+  monthKey: string,
+  plannedExpenses: PlannedExpenseItem[]
+): FinancialSnapshot => {
+  const month = snapshot.budgetMonths[monthKey];
+  if (!month) {
+    return snapshot;
+  }
+  const currency = resolveMonthCurrency(snapshot, month);
+  const plannedItems = plannedExpenses.map((expense) =>
+    toBudgetPlannedItem(expense, currency)
+  );
+  return {
+    ...snapshot,
+    budgetMonths: {
+      ...snapshot.budgetMonths,
+      [monthKey]: {
+        ...month,
+        currency,
+        plannedExpenses,
+        plannedItems
+      }
+    }
+  };
+};
+
 const toBudgetActualFromPlanned = (
   item: PlannedExpenseItem,
   currency: Currency
@@ -1021,17 +1058,15 @@ function useFinancialActions(container: FinancialStoreContainer): FinancialStore
         const key = budgetMonthKey(item.dueDate ?? item.createdAt);
         let next = ensureBudgetMonth(snapshot, key);
         const month = next.budgetMonths[key];
-        next = {
-          ...next,
-          budgetMonths: {
-            ...next.budgetMonths,
-            [key]: {
-              ...month,
-              plannedExpenses: [...month.plannedExpenses, item]
-            }
+        const plannedExpenses = [...month.plannedExpenses, item];
+        next = syncPlannedEntriesForMonth(
+          {
+            ...next,
+            plannedExpenses: []
           },
-          plannedExpenses: []
-        };
+          key,
+          plannedExpenses
+        );
         return recomputeBudgetMonth(next, key);
       });
       return item;
@@ -1059,30 +1094,15 @@ function useFinancialActions(container: FinancialStoreContainer): FinancialStore
         const withoutCurrent = next.budgetMonths[monthKey].plannedExpenses.filter((expense) => expense.id !== id);
         next = {
           ...next,
-          budgetMonths: {
-            ...next.budgetMonths,
-            [monthKey]: {
-              ...next.budgetMonths[monthKey],
-              plannedExpenses: withoutCurrent
-            }
-          },
           plannedExpenses: []
         };
+        next = syncPlannedEntriesForMonth(next, monthKey, withoutCurrent);
         const destinationMonth = next.budgetMonths[nextMonthKey];
         const existingIndex = destinationMonth.plannedExpenses.findIndex((expense) => expense.id === id);
         const updatedPlanned = existingIndex >= 0
           ? destinationMonth.plannedExpenses.map((expense) => (expense.id === id ? updatedExpense : expense))
           : [...destinationMonth.plannedExpenses, updatedExpense];
-        next = {
-          ...next,
-          budgetMonths: {
-            ...next.budgetMonths,
-            [nextMonthKey]: {
-              ...destinationMonth,
-              plannedExpenses: updatedPlanned
-            }
-          }
-        };
+        next = syncPlannedEntriesForMonth(next, nextMonthKey, updatedPlanned);
         for (const key of touched) {
           next = recomputeBudgetMonth(next, key);
         }
@@ -1099,15 +1119,9 @@ function useFinancialActions(container: FinancialStoreContainer): FinancialStore
         const plannedExpenses = month.plannedExpenses.filter((expense) => expense.id !== id);
         let next: FinancialSnapshot = {
           ...snapshot,
-          budgetMonths: {
-            ...snapshot.budgetMonths,
-            [monthKey]: {
-              ...month,
-              plannedExpenses
-            }
-          },
           plannedExpenses: []
         };
+        next = syncPlannedEntriesForMonth(next, monthKey, plannedExpenses);
         next = recomputeBudgetMonth(next, monthKey);
         return next;
       });

--- a/tasks/sync-planned-items.md
+++ b/tasks/sync-planned-items.md
@@ -1,0 +1,15 @@
+# Task: Sync planned item mutations with ledger snapshot data
+
+## Summary
+The ledger snapshot in the Smart Budgeting view reads from `budgetMonth.plannedItems`, but the store only mutates the legacy `plannedExpenses` array when users add, update, or delete planned entries. This leaves stale rows in the snapshot and causes budget totals to misreport until `plannedItems` is refreshed.
+
+## Acceptance Criteria
+- [ ] When adding a planned or recorded item, both `plannedExpenses` and `plannedItems` remain in sync.
+- [ ] Updating an existing planned entry also updates the corresponding entry within `plannedItems`.
+- [ ] Deleting a planned or recorded item removes it from `plannedItems` so the ledger snapshot immediately reflects the change.
+- [ ] `recomputeBudgetMonth` receives the refreshed `plannedItems` array so downstream totals use the latest data.
+- [ ] Manual verification from the Smart Budgeting view confirms the ledger snapshot and month totals adjust correctly after add/update/delete operations.
+
+## Implementation Notes
+- Consider deriving the updated `plannedItems` list directly from `plannedExpenses` inside `addPlannedExpense`, `updatePlannedExpense`, and `deletePlannedExpense` within `src/store/FinancialStoreProvider.tsx` before invoking `recomputeBudgetMonth`.
+- Ensure no duplicate normalisation logic is introduced—reuse existing helpers where possible.


### PR DESCRIPTION
## Summary
- derive modern planned items from updated planned expenses when months change
- reuse helper across add, update, and delete flows so ledger snapshot stays in sync

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2517bff0c832ca559d463320951e4