### PR TITLE
Refactor smart budgeting module into atomic components

### DIFF
--- a/src/features/smart-budgeting/atoms/Button.tsx
+++ b/src/features/smart-budgeting/atoms/Button.tsx
@@ -1,0 +1,39 @@
+import type { ButtonHTMLAttributes, PropsWithChildren } from 'react';
+
+type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger';
+
+const VARIANT_STYLES: Record<ButtonVariant, string> = {
+  primary:
+    'bg-accent text-slate-900 hover:bg-accent/90 disabled:opacity-60 disabled:hover:bg-accent',
+  secondary:
+    'border border-slate-700 text-slate-300 hover:border-slate-500 hover:text-slate-100 disabled:opacity-50',
+  ghost: 'text-slate-300 hover:text-slate-100 hover:bg-slate-900/60 disabled:opacity-40',
+  danger: 'bg-danger text-white hover:bg-danger/90 disabled:opacity-60'
+};
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  fullWidth?: boolean;
+}
+
+export function Button({
+  variant = 'primary',
+  className = '',
+  fullWidth,
+  children,
+  ...rest
+}: PropsWithChildren<ButtonProps>) {
+  const baseStyles =
+    'inline-flex items-center justify-center rounded-lg px-3 py-2 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950';
+  const widthClass = fullWidth ? 'w-full' : '';
+  const variantClass = VARIANT_STYLES[variant];
+  const composedClassName = [baseStyles, variantClass, widthClass, className]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <button className={composedClassName} {...rest}>
+      {children}
+    </button>
+  );
+}

--- a/src/features/smart-budgeting/atoms/Checkbox.tsx
+++ b/src/features/smart-budgeting/atoms/Checkbox.tsx
@@ -1,0 +1,10 @@
+import { forwardRef } from 'react';
+import type { InputHTMLAttributes } from 'react';
+
+export const Checkbox = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>(function Checkbox(
+  { className = '', ...props },
+  ref
+) {
+  const baseClass = 'h-4 w-4 rounded border border-slate-700 bg-slate-950 text-accent focus:ring-accent';
+  return <input ref={ref} type="checkbox" className={[baseClass, className].filter(Boolean).join(' ')} {...props} />;
+});

--- a/src/features/smart-budgeting/atoms/DialogContainer.tsx
+++ b/src/features/smart-budgeting/atoms/DialogContainer.tsx
@@ -1,0 +1,14 @@
+import type { PropsWithChildren } from 'react';
+
+interface DialogContainerProps {
+  align?: 'center' | 'top';
+}
+
+export function DialogContainer({ children, align = 'top' }: PropsWithChildren<DialogContainerProps>) {
+  const alignmentClass = align === 'center' ? 'items-center' : 'items-start';
+  return (
+    <div className={`fixed inset-0 z-50 flex ${alignmentClass} justify-center overflow-y-auto bg-slate-950/80 px-4 py-6 backdrop-blur`}>
+      {children}
+    </div>
+  );
+}

--- a/src/features/smart-budgeting/atoms/DialogSurface.tsx
+++ b/src/features/smart-budgeting/atoms/DialogSurface.tsx
@@ -1,0 +1,12 @@
+import type { PropsWithChildren } from 'react';
+
+interface DialogSurfaceProps {
+  size?: 'md' | 'lg';
+}
+
+export function DialogSurface({ children, size = 'lg' }: PropsWithChildren<DialogSurfaceProps>) {
+  const widthClass = size === 'lg' ? 'max-w-4xl' : 'max-w-2xl';
+  return (
+    <div className={`w-full ${widthClass} rounded-2xl border border-slate-800 bg-slate-900/95 p-6 shadow-2xl`}>{children}</div>
+  );
+}

--- a/src/features/smart-budgeting/atoms/Input.tsx
+++ b/src/features/smart-budgeting/atoms/Input.tsx
@@ -1,0 +1,10 @@
+import { forwardRef } from 'react';
+import type { InputHTMLAttributes } from 'react';
+
+export const Input = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>(function Input(
+  { className = '', ...props },
+  ref
+) {
+  const baseClass = 'w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm transition focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent/60 disabled:opacity-60';
+  return <input ref={ref} className={[baseClass, className].filter(Boolean).join(' ')} {...props} />;
+});

--- a/src/features/smart-budgeting/atoms/Select.tsx
+++ b/src/features/smart-budgeting/atoms/Select.tsx
@@ -1,0 +1,14 @@
+import { forwardRef } from 'react';
+import type { SelectHTMLAttributes } from 'react';
+
+export const Select = forwardRef<HTMLSelectElement, SelectHTMLAttributes<HTMLSelectElement>>(function Select(
+  { className = '', children, ...props },
+  ref
+) {
+  const baseClass = 'w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm transition focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent/60 disabled:opacity-60';
+  return (
+    <select ref={ref} className={[baseClass, className].filter(Boolean).join(' ')} {...props}>
+      {children}
+    </select>
+  );
+});

--- a/src/features/smart-budgeting/compounds/CategoryCreationPanel.tsx
+++ b/src/features/smart-budgeting/compounds/CategoryCreationPanel.tsx
@@ -1,0 +1,45 @@
+import type { SmartBudgetingController } from '../hooks/useSmartBudgetingController';
+import { Input } from '../atoms/Input';
+import { Button } from '../atoms/Button';
+
+interface CategoryCreationPanelProps {
+  dialog: SmartBudgetingController['dialog'];
+}
+
+export function CategoryCreationPanel({ dialog }: CategoryCreationPanelProps) {
+  const { categoryCreationTargetId, newCategoryName, setNewCategoryName, handleCreateCategory, handleToggleCategoryCreation } =
+    dialog;
+
+  if (!categoryCreationTargetId) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-950/70 p-4">
+      <p className="text-sm font-semibold text-slate-200">Create a new category</p>
+      <p className="text-xs text-slate-500">The new category will automatically be assigned to the selected planned expense row.</p>
+      <div className="mt-3 flex flex-col gap-2 sm:flex-row">
+        <Input
+          placeholder="Category name"
+          value={newCategoryName}
+          onChange={(event) => setNewCategoryName(event.target.value)}
+        />
+        <div className="flex gap-2">
+          <Button type="button" onClick={handleCreateCategory} disabled={!newCategoryName.trim()}>
+            Save
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => {
+              setNewCategoryName('');
+              handleToggleCategoryCreation(categoryCreationTargetId);
+            }}
+          >
+            Cancel
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/smart-budgeting/compounds/LedgerSnapshot.tsx
+++ b/src/features/smart-budgeting/compounds/LedgerSnapshot.tsx
@@ -1,0 +1,83 @@
+import type { BudgetMonth } from '../../../types';
+import type { SmartBudgetingController } from '../hooks/useSmartBudgetingController';
+import { LedgerList } from '../molecules/LedgerList';
+
+interface LedgerSnapshotProps {
+  budgetMonth: BudgetMonth;
+  utils: SmartBudgetingController['utils'];
+  periodLabel: string;
+}
+
+export function LedgerSnapshot({ budgetMonth, utils, periodLabel }: LedgerSnapshotProps) {
+  return (
+    <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-4 sm:p-6">
+      <header className="mb-4 flex items-center justify-between">
+        <div>
+          <h3 className="text-lg font-semibold text-slate-100">{`Ledger snapshot · ${periodLabel}`}</h3>
+          <p className="text-xs text-slate-500">
+            A quick glance at planned allocations, recorded actuals, and manual adjustments for the selected month.
+          </p>
+        </div>
+      </header>
+      <div className="grid gap-4 lg:grid-cols-2">
+        <LedgerList
+          title="Planned items"
+          emptyMessage="No planned allocations recorded."
+          items={budgetMonth.plannedItems}
+          getKey={(item) => item.id}
+          renderItem={(item) => (
+            <div className="flex items-center justify-between gap-3 rounded-lg border border-slate-800 bg-slate-950/70 px-3 py-2">
+              <span>{item.name}</span>
+              <span className="font-semibold text-warning">{utils.formatCurrency(item.plannedAmount)}</span>
+            </div>
+          )}
+        />
+        <LedgerList
+          title="Recorded actuals"
+          emptyMessage="No matched actuals logged yet."
+          items={budgetMonth.actuals}
+          getKey={(item) => item.id}
+          renderItem={(item) => (
+            <div className="flex items-center justify-between gap-3 rounded-lg border border-slate-800 bg-slate-950/70 px-3 py-2">
+              <span>{item.description ?? 'Unnamed actual'}</span>
+              <span className="font-semibold text-success">{utils.formatCurrency(item.amount)}</span>
+            </div>
+          )}
+        />
+        <LedgerList
+          title="Unassigned spend"
+          emptyMessage="All spend has been categorised."
+          items={budgetMonth.unassignedActuals}
+          getKey={(item) => item.id}
+          renderItem={(item) => (
+            <div className="flex items-center justify-between gap-3 rounded-lg border border-slate-800 bg-slate-950/70 px-3 py-2">
+              <span>{item.description ?? 'Unassigned transaction'}</span>
+              <span className="font-semibold text-warning">{utils.formatCurrency(item.amount)}</span>
+            </div>
+          )}
+        />
+        <LedgerList
+          title="Adjustments & rollovers"
+          emptyMessage="No manual adjustments captured."
+          items={budgetMonth.adjustments}
+          getKey={(item) => item.id}
+          renderItem={(adjustment) => (
+            <div className="space-y-1 rounded-lg border border-slate-800 bg-slate-950/70 px-3 py-2">
+              <div className="flex items-center justify-between gap-3">
+                <span>{adjustment.reason ?? 'Adjustment'}</span>
+                <span className="font-semibold text-accent">{utils.formatCurrency(adjustment.amount)}</span>
+              </div>
+              {(adjustment.rolloverSourceMonth || adjustment.rolloverTargetMonth) && (
+                <p className="text-[11px] text-slate-500">
+                  {adjustment.rolloverSourceMonth ? `From ${adjustment.rolloverSourceMonth}` : ''}
+                  {adjustment.rolloverSourceMonth && adjustment.rolloverTargetMonth ? ' → ' : ''}
+                  {adjustment.rolloverTargetMonth ? `To ${adjustment.rolloverTargetMonth}` : ''}
+                </p>
+              )}
+            </div>
+          )}
+        />
+      </div>
+    </section>
+  );
+}

--- a/src/features/smart-budgeting/compounds/PlannedExpenseRow.tsx
+++ b/src/features/smart-budgeting/compounds/PlannedExpenseRow.tsx
@@ -1,0 +1,126 @@
+import type { SmartBudgetingController } from '../hooks/useSmartBudgetingController';
+import { Checkbox } from '../atoms/Checkbox';
+import { Input } from '../atoms/Input';
+import { Select } from '../atoms/Select';
+import { Button } from '../atoms/Button';
+
+interface PlannedExpenseRowProps {
+  entry: SmartBudgetingController['dialog']['entries'][number];
+  priorityOptions: SmartBudgetingController['dialog']['PRIORITY_OPTIONS'];
+  expenseCategories: SmartBudgetingController['dialog']['expenseCategories'];
+  canRemove: boolean;
+  isCreatingCategory: boolean;
+  onEntryChange: SmartBudgetingController['dialog']['handleEntryChange'];
+  onRemove: SmartBudgetingController['dialog']['handleRemoveEntryRow'];
+  onToggleCategoryCreation: SmartBudgetingController['dialog']['handleToggleCategoryCreation'];
+  resolveDefaultDueDate: SmartBudgetingController['dialog']['resolveDefaultDueDate'];
+}
+
+export function PlannedExpenseRow({
+  entry,
+  priorityOptions,
+  expenseCategories,
+  canRemove,
+  isCreatingCategory,
+  onEntryChange,
+  onRemove,
+  onToggleCategoryCreation,
+  resolveDefaultDueDate
+}: PlannedExpenseRowProps) {
+  return (
+    <tr className="align-top">
+      <td className="px-3 py-2">
+        <Input
+          placeholder="e.g. School fees"
+          value={entry.name}
+          onChange={(event) => onEntryChange(entry.id, { name: event.target.value })}
+        />
+      </td>
+      <td className="px-3 py-2">
+        <Input
+          type="number"
+          min={0}
+          placeholder="0"
+          value={entry.amount}
+          onChange={(event) => onEntryChange(entry.id, { amount: event.target.value })}
+        />
+      </td>
+      <td className="px-3 py-2">
+        <div className="flex flex-col gap-2">
+          <Input
+            type="date"
+            value={entry.dueDate}
+            onChange={(event) => onEntryChange(entry.id, { dueDate: event.target.value })}
+            disabled={!entry.hasDueDate}
+          />
+          <label className="flex items-center gap-2 text-xs text-slate-400">
+            <Checkbox
+              checked={!entry.hasDueDate}
+              onChange={(event) => {
+                const noDueDate = event.target.checked;
+                onEntryChange(entry.id, {
+                  hasDueDate: !noDueDate,
+                  ...(noDueDate ? {} : { dueDate: entry.dueDate || resolveDefaultDueDate() })
+                });
+              }}
+            />
+            <span>No due date</span>
+          </label>
+        </div>
+      </td>
+      <td className="px-3 py-2">
+        <Select
+          value={entry.priority}
+          onChange={(event) =>
+            onEntryChange(entry.id, {
+              priority: event.target.value as (typeof priorityOptions)[number]['value']
+            })
+          }
+        >
+          {priorityOptions.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </Select>
+      </td>
+      <td className="px-3 py-2">
+        <div className="flex flex-col gap-2">
+          <Select
+            value={entry.categoryId}
+            onChange={(event) => onEntryChange(entry.id, { categoryId: event.target.value })}
+            disabled={expenseCategories.length === 0}
+          >
+            <option value="" disabled>
+              {expenseCategories.length === 0 ? 'No categories available' : 'Select category'}
+            </option>
+            {expenseCategories.map((category) => (
+              <option key={category.id} value={category.id}>
+                {category.name}
+              </option>
+            ))}
+          </Select>
+          <Button
+            type="button"
+            variant="ghost"
+            className="self-start px-0 text-xs font-semibold text-accent"
+            onClick={() => onToggleCategoryCreation(entry.id)}
+          >
+            {isCreatingCategory ? 'Cancel new category' : 'New category'}
+          </Button>
+        </div>
+      </td>
+      <td className="px-3 py-2">
+        <Button
+          type="button"
+          variant="secondary"
+          className="text-xs"
+          onClick={() => onRemove(entry.id)}
+          disabled={!canRemove}
+        >
+          Remove
+        </Button>
+      </td>
+    </tr>
+  );
+}

--- a/src/features/smart-budgeting/compounds/PlannedExpensesTable.tsx
+++ b/src/features/smart-budgeting/compounds/PlannedExpensesTable.tsx
@@ -1,0 +1,53 @@
+import type { SmartBudgetingController } from '../hooks/useSmartBudgetingController';
+import { PlannedExpenseRow } from './PlannedExpenseRow';
+
+interface PlannedExpensesTableProps {
+  dialog: SmartBudgetingController['dialog'];
+}
+
+export function PlannedExpensesTable({ dialog }: PlannedExpensesTableProps) {
+  const {
+    entries,
+    canRemoveRows,
+    handleEntryChange,
+    handleRemoveEntryRow,
+    handleToggleCategoryCreation,
+    categoryCreationTargetId,
+    expenseCategories,
+    resolveDefaultDueDate,
+    PRIORITY_OPTIONS
+  } = dialog;
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full divide-y divide-slate-800 text-sm">
+        <thead>
+          <tr className="text-left text-xs uppercase tracking-wide text-slate-500">
+            <th className="px-3 py-2 font-semibold">Name</th>
+            <th className="px-3 py-2 font-semibold">Amount (₹)</th>
+            <th className="px-3 py-2 font-semibold">Due date</th>
+            <th className="px-3 py-2 font-semibold">Priority</th>
+            <th className="px-3 py-2 font-semibold">Category</th>
+            <th className="px-3 py-2 font-semibold">Actions</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-800">
+          {entries.map((entry) => (
+            <PlannedExpenseRow
+              key={entry.id}
+              entry={entry}
+              canRemove={canRemoveRows}
+              priorityOptions={PRIORITY_OPTIONS}
+              expenseCategories={expenseCategories}
+              onEntryChange={handleEntryChange}
+              onRemove={handleRemoveEntryRow}
+              onToggleCategoryCreation={handleToggleCategoryCreation}
+              isCreatingCategory={categoryCreationTargetId === entry.id}
+              resolveDefaultDueDate={resolveDefaultDueDate}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/features/smart-budgeting/molecules/DialogFooter.tsx
+++ b/src/features/smart-budgeting/molecules/DialogFooter.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react';
+
+interface DialogFooterProps {
+  startSlot?: ReactNode;
+  endSlot?: ReactNode;
+}
+
+export function DialogFooter({ startSlot, endSlot }: DialogFooterProps) {
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex items-center gap-3">{startSlot}</div>
+      <div className="flex items-center gap-3 text-xs text-slate-400">{endSlot}</div>
+    </div>
+  );
+}

--- a/src/features/smart-budgeting/molecules/DialogHeader.tsx
+++ b/src/features/smart-budgeting/molecules/DialogHeader.tsx
@@ -1,0 +1,26 @@
+import type { PropsWithChildren, ReactNode } from 'react';
+import { Button } from '../atoms/Button';
+
+interface DialogHeaderProps {
+  title: string;
+  description?: ReactNode;
+  onClose: () => void;
+  actions?: ReactNode;
+}
+
+export function DialogHeader({ title, description, onClose, actions }: PropsWithChildren<DialogHeaderProps>) {
+  return (
+    <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+      <div className="space-y-1">
+        <h3 className="text-xl font-semibold text-slate-100">{title}</h3>
+        {description ? <div className="text-sm text-slate-400">{description}</div> : null}
+      </div>
+      <div className="flex items-center gap-2">
+        {actions}
+        <Button type="button" variant="secondary" className="text-xs uppercase tracking-wide" onClick={onClose}>
+          Close
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/smart-budgeting/molecules/LedgerList.tsx
+++ b/src/features/smart-budgeting/molecules/LedgerList.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from 'react';
+
+interface LedgerListProps<TItem> {
+  title: string;
+  emptyMessage: string;
+  items: TItem[];
+  renderItem: (item: TItem) => ReactNode;
+  getKey?: (item: TItem, index: number) => string | number;
+}
+
+export function LedgerList<TItem>({ title, emptyMessage, items, renderItem, getKey }: LedgerListProps<TItem>) {
+  return (
+    <div>
+      <h4 className="text-sm font-semibold text-slate-200">{title}</h4>
+      <ul className="mt-2 space-y-2 text-sm text-slate-300">
+        {items.length === 0 ? (
+          <li className="text-slate-500">{emptyMessage}</li>
+        ) : (
+          items.map((item, index) => {
+            const key = getKey ? getKey(item, index) : index;
+            return <li key={key}>{renderItem(item)}</li>;
+          })
+        )}
+      </ul>
+    </div>
+  );
+}

--- a/src/features/smart-budgeting/organisms/PlannedExpensesDialog.tsx
+++ b/src/features/smart-budgeting/organisms/PlannedExpensesDialog.tsx
@@ -1,32 +1,20 @@
 import { FormEvent } from 'react';
 import { Badge } from '../atoms/Badge';
 import type { SmartBudgetingController } from '../hooks/useSmartBudgetingController';
+import { DialogContainer } from '../atoms/DialogContainer';
+import { DialogSurface } from '../atoms/DialogSurface';
+import { DialogHeader } from '../molecules/DialogHeader';
+import { DialogFooter } from '../molecules/DialogFooter';
+import { Button } from '../atoms/Button';
+import { PlannedExpensesTable } from '../compounds/PlannedExpensesTable';
+import { CategoryCreationPanel } from '../compounds/CategoryCreationPanel';
 
 interface PlannedExpensesDialogProps {
   dialog: SmartBudgetingController['dialog'];
-  utils: SmartBudgetingController['utils'];
 }
 
-export function PlannedExpensesDialog({ dialog, utils }: PlannedExpensesDialogProps) {
-  const {
-    isOpen,
-    close,
-    handleSubmit,
-    entries,
-    handleEntryChange,
-    handleAddEntryRow,
-    handleRemoveEntryRow,
-    canRemoveRows,
-    expenseCategories,
-    categoryCreationTargetId,
-    handleToggleCategoryCreation,
-    newCategoryName,
-    setNewCategoryName,
-    handleCreateCategory,
-    shouldShowValidationError,
-    isSubmitting,
-    resolveDefaultDueDate
-  } = dialog;
+export function PlannedExpensesDialog({ dialog }: PlannedExpensesDialogProps) {
+  const { isOpen, close, handleSubmit, handleAddEntryRow, shouldShowValidationError, isSubmitting } = dialog;
 
   if (!isOpen) {
     return null;
@@ -37,205 +25,42 @@ export function PlannedExpensesDialog({ dialog, utils }: PlannedExpensesDialogPr
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-slate-950/80 px-4 py-6 backdrop-blur">
-      <div className="w-full max-w-4xl rounded-2xl border border-slate-800 bg-slate-900/95 p-6 shadow-2xl">
+    <DialogContainer>
+      <DialogSurface>
         <form onSubmit={onSubmit} className="space-y-6">
-          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-            <div>
-              <h3 className="text-xl font-semibold text-slate-100">Add planned expenses</h3>
-              <p className="text-sm text-slate-400">Capture multiple planned expenses at once and assign them to categories.</p>
-            </div>
-            <button
-              type="button"
-              onClick={close}
-              className="self-start rounded-lg border border-slate-700 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-300 transition hover:border-slate-500"
-            >
-              Close
-            </button>
-          </div>
+          <DialogHeader
+            title="Add planned expenses"
+            description="Capture multiple planned expenses at once and assign them to categories."
+            onClose={close}
+          />
 
-          <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-slate-800 text-sm">
-              <thead>
-                <tr className="text-left text-xs uppercase tracking-wide text-slate-500">
-                  <th className="px-3 py-2 font-semibold">Name</th>
-                  <th className="px-3 py-2 font-semibold">Amount (₹)</th>
-                  <th className="px-3 py-2 font-semibold">Due date</th>
-                  <th className="px-3 py-2 font-semibold">Priority</th>
-                  <th className="px-3 py-2 font-semibold">Category</th>
-                  <th className="px-3 py-2 font-semibold">Actions</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-slate-800">
-                {entries.map((entry) => {
-                  const isCreatingForRow = categoryCreationTargetId === entry.id;
-                  return (
-                    <tr key={entry.id} className="align-top">
-                      <td className="px-3 py-2">
-                        <input
-                          className="w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm"
-                          placeholder="e.g. School fees"
-                          value={entry.name}
-                          onChange={(event) => handleEntryChange(entry.id, { name: event.target.value })}
-                        />
-                      </td>
-                      <td className="px-3 py-2">
-                        <input
-                          type="number"
-                          min={0}
-                          className="w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm"
-                          placeholder="0"
-                          value={entry.amount}
-                          onChange={(event) => handleEntryChange(entry.id, { amount: event.target.value })}
-                        />
-                      </td>
-                      <td className="px-3 py-2">
-                        <div className="flex flex-col gap-2">
-                          <input
-                            type="date"
-                            className="w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm disabled:opacity-60"
-                            value={entry.dueDate}
-                            onChange={(event) => handleEntryChange(entry.id, { dueDate: event.target.value })}
-                            disabled={!entry.hasDueDate}
-                          />
-                          <label className="flex items-center gap-2 text-xs text-slate-400">
-                            <input
-                              type="checkbox"
-                              checked={!entry.hasDueDate}
-                              onChange={(event) => {
-                                const noDueDate = event.target.checked;
-                                handleEntryChange(entry.id, {
-                                  hasDueDate: !noDueDate,
-                                  ...(noDueDate ? {} : { dueDate: entry.dueDate || resolveDefaultDueDate() })
-                                });
-                              }}
-                            />
-                            <span>No due date</span>
-                          </label>
-                        </div>
-                      </td>
-                      <td className="px-3 py-2">
-                        <select
-                          className="w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm"
-                          value={entry.priority}
-                          onChange={(event) =>
-                            handleEntryChange(entry.id, {
-                              priority: event.target.value as (typeof utils.PRIORITY_OPTIONS)[number]['value']
-                            })
-                          }
-                        >
-                          {utils.PRIORITY_OPTIONS.map((option) => (
-                            <option key={option.value} value={option.value}>
-                              {option.label}
-                            </option>
-                          ))}
-                        </select>
-                      </td>
-                      <td className="px-3 py-2">
-                        <div className="flex flex-col gap-2">
-                          <select
-                            className="w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm"
-                            value={entry.categoryId}
-                            onChange={(event) => handleEntryChange(entry.id, { categoryId: event.target.value })}
-                            disabled={expenseCategories.length === 0}
-                          >
-                            <option value="" disabled>
-                              {expenseCategories.length === 0 ? 'No categories available' : 'Select category'}
-                            </option>
-                            {expenseCategories.map((category) => (
-                              <option key={category.id} value={category.id}>
-                                {category.name}
-                              </option>
-                            ))}
-                          </select>
-                          <button
-                            type="button"
-                            onClick={() => handleToggleCategoryCreation(entry.id)}
-                            className="self-start text-xs font-semibold text-accent"
-                          >
-                            {isCreatingForRow ? 'Cancel new category' : 'New category'}
-                          </button>
-                        </div>
-                      </td>
-                      <td className="px-3 py-2">
-                        <button
-                          type="button"
-                          onClick={() => handleRemoveEntryRow(entry.id)}
-                          className="rounded-lg border border-slate-800 px-3 py-2 text-xs font-semibold text-slate-300 transition hover:border-slate-600 hover:text-slate-100 disabled:opacity-40"
-                          disabled={!canRemoveRows}
-                        >
-                          Remove
-                        </button>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
+          <PlannedExpensesTable dialog={dialog} />
 
-          {categoryCreationTargetId && (
-            <div className="rounded-xl border border-slate-800 bg-slate-950/70 p-4">
-              <p className="text-sm font-semibold text-slate-200">Create a new category</p>
-              <p className="text-xs text-slate-500">The new category will automatically be assigned to the selected planned expense row.</p>
-              <div className="mt-3 flex flex-col gap-2 sm:flex-row">
-                <input
-                  className="w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm"
-                  placeholder="Category name"
-                  value={newCategoryName}
-                  onChange={(event) => setNewCategoryName(event.target.value)}
-                />
-                <div className="flex gap-2">
-                  <button
-                    type="button"
-                    onClick={handleCreateCategory}
-                    className="rounded-lg bg-accent px-3 py-2 text-xs font-semibold text-slate-900 disabled:opacity-50"
-                    disabled={!newCategoryName.trim()}
-                  >
-                    Save
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setNewCategoryName('');
-                      handleToggleCategoryCreation(categoryCreationTargetId);
-                    }}
-                    className="rounded-lg border border-slate-700 px-3 py-2 text-xs font-semibold text-slate-300 transition hover:border-slate-500"
-                  >
-                    Cancel
-                  </button>
-                </div>
-              </div>
-            </div>
-          )}
+          <CategoryCreationPanel dialog={dialog} />
 
-          {shouldShowValidationError && (
+          {shouldShowValidationError ? (
             <p className="text-sm text-danger">
               Please complete all required fields before saving your planned expenses. Ensure at least one expense category exists.
             </p>
-          )}
+          ) : null}
 
-          <div className="flex items-center justify-between gap-3">
-            <button
-              type="button"
-              onClick={handleAddEntryRow}
-              className="rounded-lg border border-slate-700 px-3 py-2 text-xs font-semibold text-slate-300 transition hover:border-slate-500"
-            >
-              Add another row
-            </button>
-            <div className="flex items-center gap-3 text-xs text-slate-400">
-              <Badge tone="info">Bulk planning</Badge>
-              <button
-                type="submit"
-                className="rounded-lg bg-accent px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-accent/90 disabled:opacity-60"
-                disabled={isSubmitting}
-              >
-                {isSubmitting ? 'Saving…' : 'Save planned expenses'}
-              </button>
-            </div>
-          </div>
+          <DialogFooter
+            startSlot={
+              <Button type="button" variant="secondary" className="text-xs" onClick={handleAddEntryRow}>
+                Add another row
+              </Button>
+            }
+            endSlot={
+              <>
+                <Badge tone="info">Bulk planning</Badge>
+                <Button type="submit" disabled={isSubmitting}>
+                  {isSubmitting ? 'Saving…' : 'Save planned expenses'}
+                </Button>
+              </>
+            }
+          />
         </form>
-      </div>
-    </div>
+      </DialogSurface>
+    </DialogContainer>
   );
 }

--- a/src/views/SmartBudgetingView.tsx
+++ b/src/views/SmartBudgetingView.tsx
@@ -7,6 +7,7 @@ import { useSmartBudgetingController } from '../features/smart-budgeting/hooks/u
 import { CategoryInspector } from '../features/smart-budgeting/organisms/CategoryInspector';
 import { useFinancialStore } from '../store/FinancialStoreProvider';
 import { createDefaultBudgetMonth } from '../types';
+import { LedgerSnapshot } from '../features/smart-budgeting/compounds/LedgerSnapshot';
 
 export function SmartBudgetingView() {
   const controller = useSmartBudgetingController();
@@ -14,12 +15,11 @@ export function SmartBudgetingView() {
   const { getBudgetMonth, profile } = useFinancialStore();
 
   const selectedMonth = period.selectedMonth;
-  const budgetMonth = getBudgetMonth(selectedMonth) ??
-    createDefaultBudgetMonth(selectedMonth, profile?.currency ?? 'INR');
+  const budgetMonth = getBudgetMonth(selectedMonth) ?? createDefaultBudgetMonth(selectedMonth, profile?.currency ?? 'INR');
 
   return (
     <div className="space-y-6">
-      <PlannedExpensesDialog dialog={dialog} utils={utils} />
+      <PlannedExpensesDialog dialog={dialog} />
 
       <SummaryHeaderControls
         period={period}
@@ -38,83 +38,7 @@ export function SmartBudgetingView() {
 
       <CategoryNavigator categories={categories} editing={editing} table={table} utils={utils} />
 
-      <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-4 sm:p-6">
-        <header className="mb-4 flex items-center justify-between">
-          <div>
-            <h3 className="text-lg font-semibold text-slate-100">{`Ledger snapshot · ${period.periodLabel}`}</h3>
-            <p className="text-xs text-slate-500">
-              A quick glance at planned allocations, recorded actuals, and manual adjustments for the selected month.
-            </p>
-          </div>
-        </header>
-        <div className="grid gap-4 lg:grid-cols-2">
-          <div>
-            <h4 className="text-sm font-semibold text-slate-200">Planned items</h4>
-            <ul className="mt-2 space-y-2 text-sm text-slate-300">
-              {budgetMonth.plannedItems.length === 0 && (
-                <li className="text-slate-500">No planned allocations recorded.</li>
-              )}
-              {budgetMonth.plannedItems.map((item) => (
-                <li key={item.id} className="flex items-center justify-between gap-3 rounded-lg border border-slate-800 bg-slate-950/70 px-3 py-2">
-                  <span>{item.name}</span>
-                  <span className="text-warning font-semibold">{utils.formatCurrency(item.plannedAmount)}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
-          <div>
-            <h4 className="text-sm font-semibold text-slate-200">Recorded actuals</h4>
-            <ul className="mt-2 space-y-2 text-sm text-slate-300">
-              {budgetMonth.actuals.length === 0 && (
-                <li className="text-slate-500">No matched actuals logged yet.</li>
-              )}
-              {budgetMonth.actuals.map((item) => (
-                <li key={item.id} className="flex items-center justify-between gap-3 rounded-lg border border-slate-800 bg-slate-950/70 px-3 py-2">
-                  <span>{item.description ?? 'Unnamed actual'}</span>
-                  <span className="font-semibold text-success">{utils.formatCurrency(item.amount)}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
-          <div>
-            <h4 className="text-sm font-semibold text-slate-200">Unassigned spend</h4>
-            <ul className="mt-2 space-y-2 text-sm text-slate-300">
-              {budgetMonth.unassignedActuals.length === 0 && (
-                <li className="text-slate-500">All spend has been categorised.</li>
-              )}
-              {budgetMonth.unassignedActuals.map((item) => (
-                <li key={item.id} className="flex items-center justify-between gap-3 rounded-lg border border-slate-800 bg-slate-950/70 px-3 py-2">
-                  <span>{item.description ?? 'Unassigned transaction'}</span>
-                  <span className="font-semibold text-warning">{utils.formatCurrency(item.amount)}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
-          <div>
-            <h4 className="text-sm font-semibold text-slate-200">Adjustments & rollovers</h4>
-            <ul className="mt-2 space-y-2 text-sm text-slate-300">
-              {budgetMonth.adjustments.length === 0 && (
-                <li className="text-slate-500">No manual adjustments captured.</li>
-              )}
-              {budgetMonth.adjustments.map((adjustment) => (
-                <li key={adjustment.id} className="space-y-1 rounded-lg border border-slate-800 bg-slate-950/70 px-3 py-2">
-                  <div className="flex items-center justify-between gap-3">
-                    <span>{adjustment.reason ?? 'Adjustment'}</span>
-                    <span className="font-semibold text-accent">{utils.formatCurrency(adjustment.amount)}</span>
-                  </div>
-                  {(adjustment.rolloverSourceMonth || adjustment.rolloverTargetMonth) && (
-                    <p className="text-[11px] text-slate-500">
-                      {adjustment.rolloverSourceMonth ? `From ${adjustment.rolloverSourceMonth}` : ''}
-                      {adjustment.rolloverSourceMonth && adjustment.rolloverTargetMonth ? ' → ' : ''}
-                      {adjustment.rolloverTargetMonth ? `To ${adjustment.rolloverTargetMonth}` : ''}
-                    </p>
-                  )}
-                </li>
-              ))}
-            </ul>
-          </div>
-        </div>
-      </section>
+      <LedgerSnapshot budgetMonth={budgetMonth} utils={utils} periodLabel={period.periodLabel} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add reusable atom components for buttons, dialog surfaces, and form controls in the smart budgeting feature
- split the planned expenses dialog into table, row, and category creation compounds to simplify state orchestration
- extract the ledger snapshot view into a dedicated component to streamline the smart budgeting page layout

## Testing
- npm run build
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68e2588604d8832cae82e640c52e2da7