### PR TITLE
Hide awaiting spend badge in summary scope

### DIFF
--- a/src/features/smart-budgeting/hooks/useSmartBudgetingController.tsx
+++ b/src/features/smart-budgeting/hooks/useSmartBudgetingController.tsx
@@ -1435,6 +1435,7 @@ export function useSmartBudgetingController() {
       handleSummaryScopeChange,
       selectedCategoryLabel,
       totalsForSelected,
+      selectedCategoryStatus,
       selectedStatusToken,
       selectedCategoryVariance,
       hasNavigatorResults,

--- a/src/features/smart-budgeting/organisms/SummaryGrid.tsx
+++ b/src/features/smart-budgeting/organisms/SummaryGrid.tsx
@@ -25,6 +25,7 @@ export function SummaryGrid({ overview, categories, utils }: SummaryGridProps) {
   const {
     selectedCategoryLabel,
     totalsForSelected,
+    selectedCategoryStatus,
     selectedStatusToken,
     selectedCategoryVariance,
     handleSummaryScopeChange,
@@ -98,9 +99,11 @@ export function SummaryGrid({ overview, categories, utils }: SummaryGridProps) {
               Planned {utils.formatCurrency(totalsForSelected.totalPlanned)} · Spent {utils.formatCurrency(totalsForSelected.actualTotal)}
             </p>
           </div>
-          <span className={`rounded-full px-2 py-1 text-[10px] font-semibold ${selectedStatusToken.badgeClass}`}>
-            {selectedStatusToken.label}
-          </span>
+          {selectedCategoryStatus !== 'not-spent' && (
+            <span className={`rounded-full px-2 py-1 text-[10px] font-semibold ${selectedStatusToken.badgeClass}`}>
+              {selectedStatusToken.label}
+            </span>
+          )}
         </div>
         <dl className="mt-4 grid grid-cols-3 gap-3 text-[11px] text-slate-400">
           <SummaryStat label="Planned" value={<span className="text-warning">{utils.formatCurrency(totalsForSelected.plannedFromItems)}</span>} />


### PR DESCRIPTION
## Summary
- expose the selected category status from the smart budgeting controller
- hide the summary scope badge when the status is awaiting spend to avoid showing the label

## Testing
- npm run lint *(fails: ESLint configuration missing)*

------
https://chatgpt.com/codex/tasks/task_e_68e272be82a0832cada2937fb87fdb9f