### PR TITLE
Expand smart budgeting table layout

### DIFF
--- a/src/features/smart-budgeting/hooks/useSmartBudgetingController.tsx
+++ b/src/features/smart-budgeting/hooks/useSmartBudgetingController.tsx
@@ -74,11 +74,13 @@ const PROGRESS_COLOR_BY_STATUS: Record<PlannedExpenseSpendingHealth, string> = {
 
 export type SmartBudgetingColumnKey =
   | 'category'
-  | 'earliestDue'
+  | 'item'
   | 'planned'
   | 'actual'
   | 'variance'
-  | 'actions';
+  | 'due'
+  | 'status'
+  | 'priority';
 
 type ColumnPreferences = {
   order: SmartBudgetingColumnKey[];
@@ -87,22 +89,26 @@ type ColumnPreferences = {
 };
 
 const DEFAULT_COLUMN_PREFERENCES: ColumnPreferences = {
-  order: ['category', 'earliestDue', 'planned', 'actual', 'variance', 'actions'],
+  order: ['category', 'item', 'planned', 'actual', 'variance', 'due', 'status', 'priority'],
   visible: {
     category: true,
-    earliestDue: true,
+    item: true,
     planned: true,
     actual: true,
     variance: true,
-    actions: true
+    due: true,
+    status: true,
+    priority: true
   },
   widths: {
-    category: 'minmax(0,2.6fr)',
-    earliestDue: 'minmax(110px,0.9fr)',
-    planned: 'minmax(120px,0.9fr)',
-    actual: 'minmax(120px,0.9fr)',
-    variance: 'minmax(120px,0.9fr)',
-    actions: 'minmax(220px,1fr)'
+    category: 'minmax(180px,1.4fr)',
+    item: 'minmax(220px,2fr)',
+    planned: 'minmax(120px,1fr)',
+    actual: 'minmax(150px,1.1fr)',
+    variance: 'minmax(130px,1fr)',
+    due: 'minmax(130px,0.9fr)',
+    status: 'minmax(160px,1.1fr)',
+    priority: 'minmax(120px,0.8fr)'
   }
 } as const satisfies ColumnPreferences;
 

--- a/src/features/smart-budgeting/molecules/PlannedExpenseItemCard.tsx
+++ b/src/features/smart-budgeting/molecules/PlannedExpenseItemCard.tsx
@@ -1,5 +1,6 @@
 import { formatISO } from 'date-fns';
 import { FormEvent } from 'react';
+import type { PlannedExpenseItem } from '../../../types';
 import type { PlannedExpenseDetail, SmartBudgetingController } from '../hooks/useSmartBudgetingController';
 
 interface PlannedExpenseItemCardProps {
@@ -122,39 +123,18 @@ export function PlannedExpenseItemCard({ detail, depth, categories, editing, tab
       style={{ gridTemplateColumns: table.gridTemplateColumns }}
     >
       {table.visibleColumns.map((column) => {
-        if (column === 'category') {
-          return (
-            <div key={`${detail.item.id}-${column}`} className="min-w-0 space-y-2" style={indentationStyle}>
-              <div className="flex flex-wrap items-center justify-between gap-2">
-                <div className="flex min-w-0 flex-wrap items-center gap-2">
-                  <span className="truncate text-sm font-semibold text-slate-100">{detail.item.name}</span>
-                  <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${statusToken.badgeClass}`}>
-                    {statusToken.label}
-                  </span>
-                  <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${priorityToken.badgeClass}`}>
-                    {priorityToken.label}
-                  </span>
-                </div>
-                <span className="text-[10px] text-slate-500" title={categoryName}>
+        switch (column) {
+          case 'category':
+            return (
+              <div key={`${detail.item.id}-${column}`} className="min-w-0 space-y-2" style={indentationStyle}>
+                <p className="truncate text-sm font-semibold text-slate-100" title={categoryName}>
                   {categoryName}
-                </span>
-              </div>
-              <p className="truncate text-[10px] text-slate-500" title={infoMessage}>
-                {infoMessage}
-              </p>
-              <div className="flex items-center gap-2">
-                <div className="h-1.5 w-full flex-1 overflow-hidden rounded-full bg-slate-800">
-                  <div
-                    className="h-full rounded-full"
-                    style={{ width: `${Math.max(0, Math.min(100, progressPercent))}%`, backgroundColor: progressColor }}
-                  />
-                </div>
-                <p className="text-[10px] text-slate-500">{remainderLabel}: {utils.formatCurrency(remainderDisplay)}</p>
+                </p>
                 {isEditing && (
-                  <div className="pt-1">
+                  <div className="space-y-1">
                     <label className="text-[10px] uppercase text-slate-500">Category</label>
                     <select
-                      className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950/80 px-3 py-1.5 text-xs text-slate-100 focus:border-accent focus:outline-none"
+                      className="w-full rounded-md border border-slate-700 bg-slate-950/80 px-3 py-1.5 text-xs text-slate-100 focus:border-accent focus:outline-none"
                       value={editDraft.categoryId}
                       onChange={(event) => setEditDraft((prev) => ({ ...prev, categoryId: event.target.value }))}
                       disabled={isSaving}
@@ -171,232 +151,295 @@ export function PlannedExpenseItemCard({ detail, depth, categories, editing, tab
                       ))}
                     </select>
                     {isCurrentCategoryMissing && (
-                      <p className="mt-1 text-[10px] text-warning">The original category is no longer available. Pick another one before saving.</p>
+                      <p className="text-[10px] text-warning">
+                        The original category is no longer available. Pick another one before saving.
+                      </p>
                     )}
                   </div>
                 )}
               </div>
-            </div>
-          );
-        }
-        if (column === 'earliestDue') {
-          return (
-            <div key={`${detail.item.id}-${column}`} className="flex flex-col justify-center gap-2 text-xs text-slate-300">
-              {isEditing ? (
-                <div className="space-y-2">
-                  <span className="text-sm font-semibold text-slate-100">
-                    {editDraft.hasDueDate && editDraft.dueDate
-                      ? new Date(editDraft.dueDate).toLocaleDateString('en-IN', { month: 'short', day: 'numeric' })
-                      : 'No due date'}
-                  </span>
-                  <div className="space-y-1">
-                    <label className="text-[10px] uppercase text-slate-500">Due date</label>
-                    <input
-                      type="date"
-                      className={`w-full rounded-md border bg-slate-950/80 px-3 py-1.5 text-sm text-slate-100 focus:border-accent focus:outline-none disabled:cursor-not-allowed disabled:opacity-60 ${
-                        requiresDueDate ? 'border-danger text-danger focus:border-danger' : 'border-slate-700'
-                      }`}
-                      value={editDraft.dueDate}
-                      onChange={(event) => setEditDraft((prev) => ({ ...prev, dueDate: event.target.value }))}
-                      disabled={!editDraft.hasDueDate || isSaving}
+            );
+          case 'item':
+            return (
+              <div key={`${detail.item.id}-${column}`} className="min-w-0 space-y-2">
+                <p className="truncate text-sm font-semibold text-slate-100">{detail.item.name}</p>
+                <p className="truncate text-[10px] text-slate-500" title={infoMessage}>
+                  {infoMessage}
+                </p>
+                <div className="flex items-center gap-2">
+                  <div className="h-1.5 w-full flex-1 overflow-hidden rounded-full bg-slate-800">
+                    <div
+                      className="h-full rounded-full"
+                      style={{
+                        width: `${Math.max(0, Math.min(100, progressPercent))}%`,
+                        backgroundColor: progressColor
+                      }}
                     />
                   </div>
-                  <label className="flex items-center gap-2 text-[10px] text-slate-400">
+                  <p className="text-[10px] text-slate-500">
+                    {remainderLabel}: {utils.formatCurrency(remainderDisplay)}
+                  </p>
+                </div>
+              </div>
+            );
+          case 'planned':
+            return (
+              <div key={`${detail.item.id}-${column}`} className="text-right">
+                {isEditing ? (
+                  <div className="space-y-1">
                     <input
-                      type="checkbox"
-                      className="h-3 w-3 rounded border-slate-600 bg-slate-900 text-accent focus:ring-accent"
-                      checked={!editDraft.hasDueDate}
-                      onChange={(event) => {
-                        const noDueDate = event.target.checked;
-                        setEditDraft((prev) => ({
-                          ...prev,
-                          hasDueDate: !noDueDate,
-                          dueDate: noDueDate ? '' : prev.dueDate || fallbackDueDate
-                        }));
-                      }}
+                      type="number"
+                      min={0}
+                      className={`w-full rounded-md border bg-slate-950/80 px-3 py-1.5 text-sm text-slate-100 focus:border-accent focus:outline-none ${
+                        hasPlannedError ? 'border-danger text-danger focus:border-danger' : 'border-slate-700'
+                      }`}
+                      value={editDraft.plannedAmount}
+                      onChange={(event) => setEditDraft((prev) => ({ ...prev, plannedAmount: event.target.value }))}
                       disabled={isSaving}
                     />
-                    <span>No due date</span>
-                  </label>
-                  {requiresDueDate && (
-                    <p className="text-[10px] text-danger">Select a due date or mark the item as having no due date.</p>
-                  )}
-                </div>
-              ) : (
-                <span className="text-sm font-semibold text-slate-100">{dueDateLabel}</span>
-              )}
-              <div className="flex flex-wrap items-center gap-1 text-[10px] text-slate-500">{utils.statusBadge(detail.item.status)}</div>
-            </div>
-          );
-        }
-        if (column === 'planned') {
-          return (
-            <div key={`${detail.item.id}-${column}`} className="text-right">
-              {isEditing ? (
-                <div className="space-y-1">
-                  <input
-                    type="number"
-                    min={0}
-                    className={`w-full rounded-md border bg-slate-950/80 px-3 py-1.5 text-sm text-slate-100 focus:border-accent focus:outline-none ${
-                      hasPlannedError ? 'border-danger text-danger focus:border-danger' : 'border-slate-700'
-                    }`}
-                    value={editDraft.plannedAmount}
-                    onChange={(event) => setEditDraft((prev) => ({ ...prev, plannedAmount: event.target.value }))}
-                    disabled={isSaving}
-                  />
-                  {hasPlannedError && <p className="text-[10px] text-danger">Enter a valid planned amount.</p>}
-                </div>
-              ) : (
-                <div className="space-y-1">
-                  <div className="text-sm font-semibold text-warning">{utils.formatCurrency(detail.item.plannedAmount)}</div>
-                  <div className="text-[10px] text-slate-500">Planned</div>
-                </div>
-              )}
-            </div>
-          );
-        }
-        if (column === 'actual') {
-          return (
-            <div key={`${detail.item.id}-${column}`} className="text-right">
-              {isEditing ? (
-                <div className="space-y-1">
-                  <input
-                    type="number"
-                    min={0}
-                    placeholder="Auto from transactions"
-                    className={`w-full rounded-md border bg-slate-950/80 px-3 py-1.5 text-sm text-slate-100 focus:border-accent focus:outline-none ${
-                      hasActualError ? 'border-danger text-danger focus:border-danger' : 'border-slate-700'
-                    }`}
-                    value={editDraft.actualAmount}
-                    onChange={(event) => setEditDraft((prev) => ({ ...prev, actualAmount: event.target.value }))}
-                    disabled={isRemainderProvided || isSaving}
-                  />
-                  {hasActualError && <p className="text-[10px] text-danger">Enter a valid spent amount.</p>}
-                </div>
-              ) : (
-                <div className={`space-y-1 rounded-md border border-slate-800/70 px-3 py-1.5 text-right ${actualBackgroundClass}`}>
-                  <div className={`text-sm font-semibold ${actualToneClass}`}>{utils.formatCurrency(detail.actual)}</div>
-                  <div className="text-[10px] text-slate-500">Spent</div>
-                </div>
-              )}
-            </div>
-          );
-        }
-        if (column === 'variance') {
-          return (
-            <div key={`${detail.item.id}-${column}`} className="text-right">
-              <div className={`text-sm font-semibold ${remainderColor}`}>{utils.formatCurrency(detail.variance)}</div>
-              <div className="text-[10px] text-slate-500">{varianceLabel}</div>
-              {isEditing && (
-                <div className="mt-2 space-y-1 text-right">
-                  <label className="block text-[10px] uppercase text-slate-500">Remaining amount</label>
-                  <input
-                    type="number"
-                    min={0}
-                    placeholder="Leave blank to edit spent"
-                    className={`w-full rounded-md border bg-slate-950/80 px-3 py-1.5 text-sm text-slate-100 focus:border-accent focus:outline-none ${
-                      hasRemainderError ? 'border-danger text-danger focus:border-danger' : 'border-slate-700'
-                    }`}
-                    value={editDraft.remainderAmount}
-                    onChange={(event) => setEditDraft((prev) => ({ ...prev, remainderAmount: event.target.value }))}
-                    disabled={isSaving}
-                  />
-                  <p className="text-[10px] text-slate-500">Leave empty to enter the spent amount manually.</p>
-                  {hasRemainderError && (
-                    <p className="text-[10px] text-danger">Enter a valid remaining amount or clear the field.</p>
-                  )}
-                </div>
-              )}
-            </div>
-          );
-        }
-        return (
-          <div key={`${detail.item.id}-${column}`} className="flex flex-col items-end gap-2 text-right">
-            {!isEditing && (
-              <form className="flex w-full items-center justify-end gap-2" onSubmit={handleSubmitQuickActual}>
-                <input
-                  type="number"
-                  min={0}
-                  value={quickActualDraft}
-                  onChange={(event) => handleQuickActualChange(detail.item.id, event.target.value)}
-                  placeholder={quickPlaceholder || 'Spent'}
-                  className={`w-24 rounded-md border bg-slate-950/80 px-2 py-1 text-xs text-slate-100 focus:border-accent focus:outline-none ${
-                    hasQuickActualError ? 'border-danger text-danger focus:border-danger' : 'border-slate-700'
-                  }`}
-                />
-                <button
-                  type="submit"
-                  disabled={hasQuickActualError || quickActualValue === undefined || isQuickSaving}
-                  className="rounded-md bg-accent px-2 py-1 text-[11px] font-semibold text-slate-900 transition hover:bg-accent/90 disabled:cursor-not-allowed disabled:opacity-60"
-                >
-                  {isQuickSaving ? 'Saving…' : 'Save'}
-                </button>
-              </form>
-            )}
-            {hasQuickActualError && !isEditing && (
-              <p className="text-[10px] text-danger">Enter a valid amount to save.</p>
-            )}
-            <div className="flex flex-wrap justify-end gap-1 text-[10px]">
-              <button
-                type="button"
-                className="rounded-full bg-success/15 px-2 py-1 font-semibold text-success hover:bg-success/25"
-                onClick={() => updatePlannedExpense(detail.item.id, { status: 'purchased' })}
-              >
-                Purchased
-              </button>
-              <button
-                type="button"
-                className="rounded-full bg-slate-800 px-2 py-1 text-slate-300 hover:bg-slate-700"
-                onClick={() => updatePlannedExpense(detail.item.id, { status: 'cancelled' })}
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                className="rounded-full bg-sky-500/15 px-2 py-1 font-semibold text-sky-300 hover:bg-sky-500/25"
-                onClick={() => updatePlannedExpense(detail.item.id, { status: 'reconciled' })}
-                disabled={detail.item.status === 'reconciled'}
-              >
-                Reconcile
-              </button>
-              <button
-                type="button"
-                className="rounded-full bg-danger/15 px-2 py-1 font-semibold text-danger hover:bg-danger/25"
-                onClick={() => deletePlannedExpense(detail.item.id)}
-              >
-                Delete
-              </button>
-            </div>
-            {isEditing ? (
-              <div className="flex flex-wrap justify-end gap-2">
-                <button
-                  type="button"
-                  onClick={() => void handleSaveEdit(detail)}
-                  disabled={isSaveDisabled}
-                  className="rounded-md bg-success px-3 py-1 text-[11px] font-semibold text-slate-900 transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
-                >
-                  {isSaving ? 'Saving…' : 'Save changes'}
-                </button>
-                <button
-                  type="button"
-                  onClick={handleCancelEdit}
-                  disabled={isSaving}
-                  className="rounded-md border border-slate-700 px-3 py-1 text-[11px] font-semibold text-slate-300 hover:border-accent hover:text-accent disabled:cursor-not-allowed disabled:opacity-60"
-                >
-                  Cancel
-                </button>
+                    {hasPlannedError && <p className="text-[10px] text-danger">Enter a valid planned amount.</p>}
+                  </div>
+                ) : (
+                  <div className="space-y-1">
+                    <div className="text-sm font-semibold text-warning">{utils.formatCurrency(detail.item.plannedAmount)}</div>
+                    <div className="text-[10px] text-slate-500">Planned</div>
+                  </div>
+                )}
               </div>
-            ) : (
-              <button
-                type="button"
-                onClick={() => handleStartEdit(detail)}
-                className="text-[11px] font-semibold text-accent hover:text-accent/80"
-              >
-                Edit details
-              </button>
-            )}
-          </div>
-        );
+            );
+          case 'actual':
+            return (
+              <div key={`${detail.item.id}-${column}`} className="space-y-2 text-right">
+                {isEditing ? (
+                  <div className="space-y-1">
+                    <input
+                      type="number"
+                      min={0}
+                      placeholder="Auto from transactions"
+                      className={`w-full rounded-md border bg-slate-950/80 px-3 py-1.5 text-sm text-slate-100 focus:border-accent focus:outline-none ${
+                        hasActualError ? 'border-danger text-danger focus:border-danger' : 'border-slate-700'
+                      }`}
+                      value={editDraft.actualAmount}
+                      onChange={(event) => setEditDraft((prev) => ({ ...prev, actualAmount: event.target.value }))}
+                      disabled={isRemainderProvided || isSaving}
+                    />
+                    {hasActualError && <p className="text-[10px] text-danger">Enter a valid spent amount.</p>}
+                  </div>
+                ) : (
+                  <div className={`space-y-1 rounded-md border border-slate-800/70 px-3 py-1.5 text-right ${actualBackgroundClass}`}>
+                    <div className={`text-sm font-semibold ${actualToneClass}`}>{utils.formatCurrency(detail.actual)}</div>
+                    <div className="text-[10px] text-slate-500">Spent</div>
+                  </div>
+                )}
+                {!isEditing && (
+                  <form className="flex w-full items-center justify-end gap-2" onSubmit={handleSubmitQuickActual}>
+                    <input
+                      type="number"
+                      min={0}
+                      value={quickActualDraft}
+                      onChange={(event) => handleQuickActualChange(detail.item.id, event.target.value)}
+                      placeholder={quickPlaceholder || 'Spent'}
+                      className={`w-24 rounded-md border bg-slate-950/80 px-2 py-1 text-xs text-slate-100 focus:border-accent focus:outline-none ${
+                        hasQuickActualError ? 'border-danger text-danger focus:border-danger' : 'border-slate-700'
+                      }`}
+                    />
+                    <button
+                      type="submit"
+                      disabled={hasQuickActualError || quickActualValue === undefined || isQuickSaving}
+                      className="rounded-md bg-accent px-2 py-1 text-[11px] font-semibold text-slate-900 transition hover:bg-accent/90 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      {isQuickSaving ? 'Saving…' : 'Save'}
+                    </button>
+                  </form>
+                )}
+                {hasQuickActualError && !isEditing && (
+                  <p className="text-[10px] text-danger">Enter a valid amount to save.</p>
+                )}
+              </div>
+            );
+          case 'variance':
+            return (
+              <div key={`${detail.item.id}-${column}`} className="space-y-2 text-right">
+                <div className={`text-sm font-semibold ${remainderColor}`}>{utils.formatCurrency(detail.variance)}</div>
+                <div className="text-[10px] text-slate-500">{varianceLabel}</div>
+                <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold ${statusToken.badgeClass}`}>
+                  {statusToken.label}
+                </span>
+                {isEditing && (
+                  <div className="space-y-1 text-right">
+                    <label className="block text-[10px] uppercase text-slate-500">Remaining amount</label>
+                    <input
+                      type="number"
+                      min={0}
+                      placeholder="Leave blank to edit spent"
+                      className={`w-full rounded-md border bg-slate-950/80 px-3 py-1.5 text-sm text-slate-100 focus:border-accent focus:outline-none ${
+                        hasRemainderError ? 'border-danger text-danger focus:border-danger' : 'border-slate-700'
+                      }`}
+                      value={editDraft.remainderAmount}
+                      onChange={(event) => setEditDraft((prev) => ({ ...prev, remainderAmount: event.target.value }))}
+                      disabled={isSaving}
+                    />
+                    <p className="text-[10px] text-slate-500">Leave empty to enter the spent amount manually.</p>
+                    {hasRemainderError && (
+                      <p className="text-[10px] text-danger">Enter a valid remaining amount or clear the field.</p>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          case 'due':
+            return (
+              <div key={`${detail.item.id}-${column}`} className="flex flex-col justify-center gap-2 text-xs text-slate-300">
+                {isEditing ? (
+                  <div className="space-y-2">
+                    <span className="text-sm font-semibold text-slate-100">
+                      {editDraft.hasDueDate && editDraft.dueDate
+                        ? new Date(editDraft.dueDate).toLocaleDateString('en-IN', { month: 'short', day: 'numeric' })
+                        : 'No due date'}
+                    </span>
+                    <div className="space-y-1">
+                      <label className="text-[10px] uppercase text-slate-500">Due date</label>
+                      <input
+                        type="date"
+                        className={`w-full rounded-md border bg-slate-950/80 px-3 py-1.5 text-sm text-slate-100 focus:border-accent focus:outline-none disabled:cursor-not-allowed disabled:opacity-60 ${
+                          requiresDueDate ? 'border-danger text-danger focus:border-danger' : 'border-slate-700'
+                        }`}
+                        value={editDraft.dueDate}
+                        onChange={(event) => setEditDraft((prev) => ({ ...prev, dueDate: event.target.value }))}
+                        disabled={!editDraft.hasDueDate || isSaving}
+                      />
+                    </div>
+                    <label className="flex items-center gap-2 text-[10px] text-slate-400">
+                      <input
+                        type="checkbox"
+                        className="h-3 w-3 rounded border-slate-600 bg-slate-900 text-accent focus:ring-accent"
+                        checked={!editDraft.hasDueDate}
+                        onChange={(event) => {
+                          const noDueDate = event.target.checked;
+                          setEditDraft((prev) => ({
+                            ...prev,
+                            hasDueDate: !noDueDate,
+                            dueDate: noDueDate ? '' : prev.dueDate || fallbackDueDate
+                          }));
+                        }}
+                        disabled={isSaving}
+                      />
+                      <span>No due date</span>
+                    </label>
+                    {requiresDueDate && (
+                      <p className="text-[10px] text-danger">Select a due date or mark the item as having no due date.</p>
+                    )}
+                  </div>
+                ) : (
+                  <span className="text-sm font-semibold text-slate-100">{dueDateLabel}</span>
+                )}
+              </div>
+            );
+          case 'status':
+            return (
+              <div key={`${detail.item.id}-${column}`} className="space-y-2 text-left">
+                <div className="flex flex-wrap items-center gap-2 text-[10px] text-slate-400">
+                  {utils.statusBadge(detail.item.status)}
+                  <span className={`rounded-full px-2 py-0.5 font-semibold ${statusToken.badgeClass}`}>
+                    {statusToken.label}
+                  </span>
+                </div>
+                <div className="flex flex-wrap gap-1 text-[10px]">
+                  <button
+                    type="button"
+                    className="rounded-full bg-success/15 px-2 py-1 font-semibold text-success hover:bg-success/25"
+                    onClick={() => updatePlannedExpense(detail.item.id, { status: 'purchased' })}
+                  >
+                    Purchased
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded-full bg-slate-800 px-2 py-1 text-slate-300 hover:bg-slate-700"
+                    onClick={() => updatePlannedExpense(detail.item.id, { status: 'cancelled' })}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded-full bg-sky-500/15 px-2 py-1 font-semibold text-sky-300 hover:bg-sky-500/25"
+                    onClick={() => updatePlannedExpense(detail.item.id, { status: 'reconciled' })}
+                    disabled={detail.item.status === 'reconciled'}
+                  >
+                    Reconcile
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded-full bg-danger/15 px-2 py-1 font-semibold text-danger hover:bg-danger/25"
+                    onClick={() => deletePlannedExpense(detail.item.id)}
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+            );
+          case 'priority':
+            return (
+              <div key={`${detail.item.id}-${column}`} className="space-y-2 text-left">
+                {isEditing ? (
+                  <>
+                    <div className="space-y-1">
+                      <label className="text-[10px] uppercase text-slate-500">Priority</label>
+                      <select
+                        className="w-full rounded-md border border-slate-700 bg-slate-950/80 px-3 py-1.5 text-xs text-slate-100 focus:border-accent focus:outline-none"
+                        value={editDraft.priority}
+                        onChange={(event) =>
+                          setEditDraft((prev) => ({
+                            ...prev,
+                            priority: event.target.value as PlannedExpenseItem['priority']
+                          }))
+                        }
+                        disabled={isSaving}
+                      >
+                        {utils.PRIORITY_OPTIONS.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        onClick={() => void handleSaveEdit(detail)}
+                        disabled={isSaveDisabled}
+                        className="rounded-md bg-success px-3 py-1 text-[11px] font-semibold text-slate-900 transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        {isSaving ? 'Saving…' : 'Save changes'}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={handleCancelEdit}
+                        disabled={isSaving}
+                        className="rounded-md border border-slate-700 px-3 py-1 text-[11px] font-semibold text-slate-300 hover:border-accent hover:text-accent disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold ${priorityToken.badgeClass}`}>
+                      {priorityToken.label}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => handleStartEdit(detail)}
+                      className="text-[11px] font-semibold text-accent hover:text-accent/80"
+                    >
+                      Edit details
+                    </button>
+                  </>
+                )}
+              </div>
+            );
+          default:
+            return null;
+        }
       })}
     </div>
   );

--- a/src/features/smart-budgeting/organisms/CategoryNavigator.tsx
+++ b/src/features/smart-budgeting/organisms/CategoryNavigator.tsx
@@ -48,13 +48,25 @@ export function CategoryNavigator({ categories, editing, table, utils }: Categor
   } = categories;
   const { visibleColumns, gridTemplateColumns } = table;
   const columnLabels: Record<SmartBudgetingColumnKey, string> = {
-    category: 'Category / Planned items',
-    earliestDue: 'Earliest due',
+    category: 'Category',
+    item: 'Item',
     planned: 'Planned',
     actual: 'Actual',
     variance: 'Variance',
-    actions: 'Actions'
+    due: 'Due',
+    status: 'Status',
+    priority: 'Priority'
   } as const;
+  const headerAlignment: Record<SmartBudgetingColumnKey, string> = {
+    category: 'text-left',
+    item: 'text-left',
+    planned: 'text-right',
+    actual: 'text-right',
+    variance: 'text-right',
+    due: 'text-left',
+    status: 'text-left',
+    priority: 'text-left'
+  };
 
   const renderCategorySection = (category: CategoryNode, depth = 0): JSX.Element | null => {
     const summary = categorySummaries.get(category.id) ?? {
@@ -138,98 +150,113 @@ export function CategoryNavigator({ categories, editing, table, utils }: Categor
           style={{ gridTemplateColumns }}
         >
           {visibleColumns.map((column) => {
-            if (column === 'category') {
-              return (
-                <div
-                  key={`${category.id}-${column}`}
-                  className="flex min-w-0 items-center gap-3"
-                  style={{ paddingLeft: indentation }}
-                >
-                  <button
-                    type="button"
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      handleToggle();
-                    }}
-                    aria-expanded={Boolean(isExpanded)}
-                    aria-disabled={!canExpand}
-                    className={`flex h-6 w-6 items-center justify-center rounded-md border border-slate-700 bg-slate-950/60 text-slate-400 transition ${
-                      canExpand ? 'hover:border-accent hover:text-accent' : 'cursor-default opacity-40'
-                    }`}
+            switch (column) {
+              case 'category':
+                return (
+                  <div
+                    key={`${category.id}-${column}`}
+                    className="flex min-w-0 items-center gap-3"
+                    style={{ paddingLeft: indentation }}
                   >
-                    {canExpand ? (
-                      <span
-                        aria-hidden
-                        className={`flex items-center justify-center transition-transform ${isExpanded ? 'rotate-90' : ''}`}
-                      >
-                        <ChevronRightIcon />
+                    <button
+                      type="button"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        handleToggle();
+                      }}
+                      aria-expanded={Boolean(isExpanded)}
+                      aria-disabled={!canExpand}
+                      className={`flex h-6 w-6 items-center justify-center rounded-md border border-slate-700 bg-slate-950/60 text-slate-400 transition ${
+                        canExpand ? 'hover:border-accent hover:text-accent' : 'cursor-default opacity-40'
+                      }`}
+                    >
+                      {canExpand ? (
+                        <span
+                          aria-hidden
+                          className={`flex items-center justify-center transition-transform ${isExpanded ? 'rotate-90' : ''}`}
+                        >
+                          <ChevronRightIcon />
+                        </span>
+                      ) : (
+                        <span aria-hidden className="block h-1.5 w-1.5 rounded-full bg-current" />
+                      )}
+                      <span className="sr-only">
+                        {canExpand ? (isExpanded ? 'Collapse category' : 'Expand category') : 'No nested items'}
                       </span>
-                    ) : (
-                      <span aria-hidden className="block h-1.5 w-1.5 rounded-full bg-current" />
-                    )}
-                    <span className="sr-only">
-                      {canExpand ? (isExpanded ? 'Collapse category' : 'Expand category') : 'No nested items'}
-                    </span>
-                  </button>
-                  <div className="min-w-0 space-y-1">
-                    <div className="flex flex-wrap items-center gap-2">
+                    </button>
+                    <div className="min-w-0">
                       <p className="truncate text-sm font-semibold text-slate-100">{category.name}</p>
-                      <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${statusToken.badgeClass}`}>
-                        {statusToken.label}
-                      </span>
-                    </div>
-                    <div className="flex flex-wrap items-center gap-2 text-[10px] text-slate-500">
-                      <span>{summary.itemCount} planned item{summary.itemCount === 1 ? '' : 's'}</span>
-                      {nextDueLabel && <span>Next due {nextDueLabel}</span>}
                     </div>
                   </div>
-                </div>
-              );
+                );
+              case 'item':
+                return (
+                  <div key={`${category.id}-${column}`} className="min-w-0 space-y-1 text-xs text-slate-400">
+                    <p>
+                      {summary.itemCount} planned item{summary.itemCount === 1 ? '' : 's'}
+                    </p>
+                    <p className={nextDueLabel ? 'text-slate-500' : 'text-slate-600'}>
+                      {nextDueLabel ? `Next due ${nextDueLabel}` : 'No upcoming due dates'}
+                    </p>
+                  </div>
+                );
+              case 'planned':
+                return (
+                  <div
+                    key={`${category.id}-${column}`}
+                    className="whitespace-nowrap text-right text-sm font-semibold text-warning"
+                  >
+                    {utils.formatCurrency(summary.planned)}
+                  </div>
+                );
+              case 'actual':
+                return (
+                  <div
+                    key={`${category.id}-${column}`}
+                    className="whitespace-nowrap text-right text-sm font-semibold text-slate-200"
+                  >
+                    {utils.formatCurrency(summary.actual)}
+                  </div>
+                );
+              case 'variance':
+                return (
+                  <div
+                    key={`${category.id}-${column}`}
+                    className="flex flex-nowrap items-center justify-end gap-2 text-right"
+                  >
+                    <span className={`whitespace-nowrap text-sm font-semibold ${remainderClass}`}>
+                      {utils.formatCurrency(summary.variance)}
+                    </span>
+                    <span className="whitespace-nowrap rounded-full bg-slate-900/40 px-2 py-0.5 text-[10px] text-slate-400">
+                      {remainderDescriptor}
+                    </span>
+                  </div>
+                );
+              case 'due':
+                return (
+                  <div key={`${category.id}-${column}`} className="flex items-center gap-2 text-xs text-slate-300">
+                    <CalendarIcon className={`h-4 w-4 ${dueIconClass}`} />
+                    <span className={`whitespace-nowrap text-sm font-semibold ${dueTextClass}`}>{dueDisplayLabel}</span>
+                  </div>
+                );
+              case 'status':
+                return (
+                  <div key={`${category.id}-${column}`} className="flex flex-wrap items-center gap-2 text-[10px]">
+                    <span className={`rounded-full px-2 py-0.5 font-semibold ${statusToken.badgeClass}`}>
+                      {statusToken.label}
+                    </span>
+                    <span className="text-slate-400">{remainderDescriptor}</span>
+                  </div>
+                );
+              case 'priority':
+                return (
+                  <div key={`${category.id}-${column}`} className="text-sm text-slate-600">
+                    —
+                  </div>
+                );
+              default:
+                return null;
             }
-            if (column === 'earliestDue') {
-              return (
-                <div key={`${category.id}-${column}`} className="flex items-center justify-end gap-2 text-xs text-slate-300">
-                  <CalendarIcon className={`h-4 w-4 ${dueIconClass}`} />
-                  <span className={`whitespace-nowrap text-sm font-semibold ${dueTextClass}`}>{dueDisplayLabel}</span>
-                </div>
-              );
-            }
-            if (column === 'planned') {
-              return (
-                <div
-                  key={`${category.id}-${column}`}
-                  className="whitespace-nowrap text-right text-sm font-semibold text-warning"
-                >
-                  {utils.formatCurrency(summary.planned)}
-                </div>
-              );
-            }
-            if (column === 'actual') {
-              return (
-                <div
-                  key={`${category.id}-${column}`}
-                  className="whitespace-nowrap text-right text-sm font-semibold text-slate-200"
-                >
-                  {utils.formatCurrency(summary.actual)}
-                </div>
-              );
-            }
-            if (column === 'variance') {
-              return (
-                <div
-                  key={`${category.id}-${column}`}
-                  className="flex flex-nowrap items-center justify-end gap-2 text-right"
-                >
-                  <span className={`whitespace-nowrap text-sm font-semibold ${remainderClass}`}>
-                    {utils.formatCurrency(summary.variance)}
-                  </span>
-                  <span className="whitespace-nowrap rounded-full bg-slate-900/40 px-2 py-0.5 text-[10px] text-slate-400">
-                    {remainderDescriptor}
-                  </span>
-                </div>
-              );
-            }
-            return <div key={`${category.id}-${column}`} className="flex items-center justify-end" />;
           })}
         </div>
         {isExpanded && (
@@ -332,7 +359,7 @@ export function CategoryNavigator({ categories, editing, table, utils }: Categor
                     style={{ gridTemplateColumns }}
                   >
                     {visibleColumns.map((column) => (
-                      <span key={`header-${column}`} className={column === 'category' ? '' : 'text-right'}>
+                      <span key={`header-${column}`} className={headerAlignment[column] ?? 'text-left'}>
                         {columnLabels[column]}
                       </span>
                     ))}

--- a/src/features/smart-budgeting/organisms/NavigatorFilters.tsx
+++ b/src/features/smart-budgeting/organisms/NavigatorFilters.tsx
@@ -112,12 +112,14 @@ export function NavigatorFilters({ categories, table, onOpenDialog, onExpandAll,
   } = categories;
   const columnMenuId = useId();
   const columnLabels: Record<SmartBudgetingController['table']['columnPreferences']['order'][number], string> = {
-    category: 'Category / Planned items',
-    earliestDue: 'Earliest due date',
+    category: 'Category',
+    item: 'Item',
     planned: 'Planned amount',
     actual: 'Actual amount',
     variance: 'Variance / remaining',
-    actions: 'Actions'
+    due: 'Due date',
+    status: 'Status',
+    priority: 'Priority'
   } as const;
 
   return (


### PR DESCRIPTION
## Summary
- expand the smart budgeting column configuration to the eight-column layout and update default widths/visibility
- rework the category navigator header and rows to output dedicated category, item, due, status, and priority cells
- refactor the planned expense row renderer to separate category/item content and expose due, status, and priority data alongside existing controls

## Testing
- npm run lint *(fails: missing ESLint configuration in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68e27d2aeedc832c80fae0aa746e84a4