### PR TITLE
Refactor smart budgeting navigator for detail focus

### DIFF
--- a/src/features/smart-budgeting/hooks/useSmartBudgetingController.tsx
+++ b/src/features/smart-budgeting/hooks/useSmartBudgetingController.tsx
@@ -306,23 +306,6 @@ export function useSmartBudgetingController() {
 
   const categoryLookup = useMemo(() => new Map(categories.map((category) => [category.id, category])), [categories]);
 
-  const categoryParentMap = useMemo(() => {
-    const map = new Map<string, string | null>();
-    expenseCategories.forEach((category) => {
-      if (!category.parentId) {
-        map.set(category.id, null);
-        return;
-      }
-      const parent = categoryLookup.get(category.parentId);
-      if (parent && parent.type === 'expense') {
-        map.set(category.id, parent.id);
-      } else {
-        map.set(category.id, null);
-      }
-    });
-    return map;
-  }, [expenseCategories, categoryLookup]);
-
   useEffect(() => {
     if (selectedCategoryId !== 'all' && !categoryLookup.has(selectedCategoryId)) {
       setSelectedCategoryId('all');
@@ -388,7 +371,6 @@ export function useSmartBudgetingController() {
     [allExpenseIdsSet, expenseDescendantsMap]
   );
 
-  const [expandedCategories, setExpandedCategories] = useState<Record<string, boolean>>({});
   const [editingItemId, setEditingItemId] = useState<string | null>(null);
   const [editDraft, setEditDraft] = useState({
     categoryId: '',
@@ -406,6 +388,7 @@ export function useSmartBudgetingController() {
   const [navigatorView, setNavigatorView] = useState<'category' | 'priority'>('category');
   const [categorySearchTerm, setCategorySearchTerm] = useState('');
   const [focusedCategoryId, setFocusedCategoryId] = useState<string | null>(null);
+  const [focusedDetailId, setFocusedDetailId] = useState<string | null>(null);
   const [budgetDraft, setBudgetDraft] = useState('');
   const [isSavingBudget, setIsSavingBudget] = useState(false);
   const [budgetError, setBudgetError] = useState<string | null>(null);
@@ -424,18 +407,6 @@ export function useSmartBudgetingController() {
   ];
 
   const normalisedSearchTerm = categorySearchTerm.trim().toLowerCase();
-
-  useEffect(() => {
-    setExpandedCategories((previous) => {
-      const next: Record<string, boolean> = {};
-      expenseCategories.forEach((category) => {
-        const parent = expenseCategories.find((candidate) => candidate.id === category.parentId);
-        const isRoot = !category.parentId || !parent;
-        next[category.id] = previous[category.id] ?? isRoot;
-      });
-      return next;
-    });
-  }, [expenseCategories]);
 
   useEffect(() => {
     setBudgetError(null);
@@ -497,6 +468,12 @@ export function useSmartBudgetingController() {
     () => new Map(plannedExpenseDetails.map((detail) => [detail.item.id, detail])),
     [plannedExpenseDetails]
   );
+
+  useEffect(() => {
+    if (focusedDetailId && !plannedDetailsById.has(focusedDetailId)) {
+      setFocusedDetailId(null);
+    }
+  }, [focusedDetailId, plannedDetailsById]);
 
   const matchedTransactionIds = useMemo(
     () =>
@@ -652,6 +629,39 @@ export function useSmartBudgetingController() {
     [expenseCategories, categorySummaries]
   );
 
+  const activeCategoryIds = useMemo(() => {
+    if (selectedCategoryId === 'all') {
+      return null;
+    }
+    return resolveCategoryIds(selectedCategoryId);
+  }, [resolveCategoryIds, selectedCategoryId]);
+
+  const visibleNavigatorDetails = useMemo(() => {
+    return plannedExpenseDetails.filter((detail) => {
+      if (activeCategoryIds && !activeCategoryIds.has(detail.item.categoryId)) {
+        return false;
+      }
+      if (navigatorFilter !== 'all' && detail.status !== navigatorFilter) {
+        return false;
+      }
+      if (normalisedSearchTerm === '') {
+        return true;
+      }
+      const categoryName =
+        categoryLookup.get(detail.item.categoryId)?.name?.toLowerCase() ?? 'uncategorised';
+      return (
+        detail.item.name.toLowerCase().includes(normalisedSearchTerm) ||
+        categoryName.includes(normalisedSearchTerm)
+      );
+    });
+  }, [
+    plannedExpenseDetails,
+    activeCategoryIds,
+    navigatorFilter,
+    normalisedSearchTerm,
+    categoryLookup
+  ]);
+
   useEffect(() => {
     if (editingItemId && !periodPlannedExpenses.some((item) => item.id === editingItemId)) {
       setEditingItemId(null);
@@ -683,24 +693,11 @@ export function useSmartBudgetingController() {
     setBudgetDraft(typeof budgetValue === 'number' && !Number.isNaN(budgetValue) ? String(budgetValue) : '');
   }, [focusedCategoryId, categoryLookup, viewMode]);
 
-  const uncategorisedDetails = useMemo(
-    () => plannedExpenseDetails.filter((detail) => !expenseCategoryIds.has(detail.item.categoryId)),
-    [plannedExpenseDetails, expenseCategoryIds]
-  );
-
-  const visibleUncategorisedDetails = useMemo(
-    () =>
-      uncategorisedDetails.filter((detail) => {
-        const matchesFilter = navigatorFilter === 'all' || detail.status === navigatorFilter;
-        const matchesSearch =
-          normalisedSearchTerm === '' || detail.item.name.toLowerCase().includes(normalisedSearchTerm);
-        return matchesFilter && matchesSearch;
-      }),
-    [uncategorisedDetails, navigatorFilter, normalisedSearchTerm]
-  );
-
   const filteredPriorityDetails = useMemo(() => {
     return plannedExpenseDetails.filter((detail) => {
+      if (activeCategoryIds && !activeCategoryIds.has(detail.item.categoryId)) {
+        return false;
+      }
       const matchesFilter = navigatorFilter === 'all' || detail.status === navigatorFilter;
       if (!matchesFilter) {
         return false;
@@ -713,7 +710,13 @@ export function useSmartBudgetingController() {
         detail.item.name.toLowerCase().includes(normalisedSearchTerm) || categoryName.includes(normalisedSearchTerm)
       );
     });
-  }, [plannedExpenseDetails, navigatorFilter, normalisedSearchTerm, categoryLookup]);
+  }, [
+    plannedExpenseDetails,
+    activeCategoryIds,
+    navigatorFilter,
+    normalisedSearchTerm,
+    categoryLookup
+  ]);
 
   const priorityGroups = useMemo(() => {
     const groups: Record<PlannedExpenseItem['priority'], PlannedExpenseDetail[]> = {
@@ -802,23 +805,6 @@ export function useSmartBudgetingController() {
     completed.sort((a, b) => new Date(b.item.dueDate).getTime() - new Date(a.item.dueDate).getTime());
     return completed.slice(0, 3);
   }, [inspectorDetails]);
-
-  const updateAllCategoryExpansion = (expanded: boolean) => {
-    const next: Record<string, boolean> = {};
-    const visit = (nodes: CategoryNode[]) => {
-      nodes.forEach((node) => {
-        next[node.id] = expanded;
-        if (node.children.length > 0) {
-          visit(node.children);
-        }
-      });
-    };
-    visit(expenseCategoryTree);
-    setExpandedCategories(next);
-  };
-
-  const expandAllCategories = () => updateAllCategoryExpansion(true);
-  const collapseAllCategories = () => updateAllCategoryExpansion(false);
 
   const statusBadge = (status: PlannedExpenseItem['status']) => {
     const baseClass = 'inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide';
@@ -945,30 +931,21 @@ export function useSmartBudgetingController() {
   const shouldShowValidationError = hasAttemptedSubmit && (hasInvalidEntries || expenseCategories.length === 0);
   const canRemoveRows = plannedEntries.length > 1;
 
-  const toggleCategory = (id: string) => {
-    setExpandedCategories((previous) => ({ ...previous, [id]: !previous[id] }));
-  };
-
-  function focusCategory(id: string, expandSelf = false) {
+  function focusCategory(id: string) {
     setFocusedCategoryId(id);
-    setExpandedCategories((previous) => {
-      const next = { ...previous } as Record<string, boolean>;
-      let currentParent = categoryParentMap.get(id) ?? null;
-      while (currentParent) {
-        next[currentParent] = true;
-        currentParent = categoryParentMap.get(currentParent) ?? null;
+    setFocusedDetailId((previous) => {
+      if (!previous) {
+        return null;
       }
-      if (expandSelf) {
-        next[id] = true;
-      }
-      return next;
+      const detail = plannedDetailsById.get(previous);
+      return detail && detail.item.categoryId === id ? previous : null;
     });
   }
 
   const handleSummaryScopeChange = (value: 'all' | string) => {
     setSelectedCategoryId(value);
     if (value !== 'all') {
-      focusCategory(value, true);
+      focusCategory(value);
     }
   };
 
@@ -1050,6 +1027,8 @@ export function useSmartBudgetingController() {
 
   const handleStartEdit = (detail: PlannedExpenseDetail) => {
     setEditingItemId(detail.item.id);
+    setFocusedDetailId(detail.item.id);
+    setFocusedCategoryId(detail.item.categoryId);
     const manualActual =
       typeof detail.item.actualAmount === 'number' && !Number.isNaN(detail.item.actualAmount)
         ? detail.item.actualAmount
@@ -1167,7 +1146,11 @@ export function useSmartBudgetingController() {
     setNavigatorFilter('all');
     setCategorySearchTerm('');
     setNavigatorView('category');
-    focusCategory(detail.item.categoryId, true);
+    setFocusedCategoryId(detail.item.categoryId);
+    setFocusedDetailId(detail.item.id);
+    if (activeCategoryIds && !activeCategoryIds.has(detail.item.categoryId)) {
+      setSelectedCategoryId('all');
+    }
     handleStartEdit(detail);
   };
 
@@ -1187,7 +1170,8 @@ export function useSmartBudgetingController() {
       : 'over';
   const selectedStatusToken = SPENDING_BADGE_STYLES[selectedCategoryStatus];
   const baselineLabel = viewMode === 'monthly' ? 'Monthly baseline (₹)' : 'Yearly baseline (₹)';
-  const hasNavigatorResults = expenseCategoryTree.length > 0 || visibleUncategorisedDetails.length > 0;
+  const hasNavigatorResults =
+    visibleNavigatorDetails.length > 0 || filteredPriorityDetails.length > 0;
 
   const tableConfig = useMemo(
     () => ({
@@ -1407,17 +1391,12 @@ export function useSmartBudgetingController() {
     categories: {
       options: categoryOptions,
       lookup: categoryLookup,
-      tree: expenseCategoryTree,
-      expanded: expandedCategories,
-      toggleCategory,
       focusCategory,
-      expandAllCategories,
-      collapseAllCategories,
       categorySummaries,
       itemsByCategory,
       expenseDescendantsMap,
       expenseCategoryIds,
-      visibleUncategorisedDetails,
+      visibleNavigatorDetails,
       navigatorFilter,
       setNavigatorFilter,
       navigatorFilterOptions,
@@ -1431,6 +1410,8 @@ export function useSmartBudgetingController() {
       visibleCategoryDetails: plannedExpenseDetails,
       focusedCategoryId,
       setFocusedCategoryId,
+      focusedDetailId,
+      setFocusedDetailId,
       selectedCategoryId,
       handleSummaryScopeChange,
       selectedCategoryLabel,
@@ -1440,8 +1421,6 @@ export function useSmartBudgetingController() {
       selectedCategoryVariance,
       hasNavigatorResults,
       setSelectedCategoryId,
-      renderedCategories: expenseCategoryTree,
-      categoryParentMap,
       handleResetFilters
     },
     overview: {

--- a/src/features/smart-budgeting/molecules/PlannedExpenseItemCard.tsx
+++ b/src/features/smart-budgeting/molecules/PlannedExpenseItemCard.tsx
@@ -9,9 +9,20 @@ interface PlannedExpenseItemCardProps {
   editing: SmartBudgetingController['editing'];
   table: SmartBudgetingController['table'];
   utils: SmartBudgetingController['utils'];
+  isFocused?: boolean;
+  rowRef?: (element: HTMLDivElement | null) => void;
 }
 
-export function PlannedExpenseItemCard({ detail, depth, categories, editing, table, utils }: PlannedExpenseItemCardProps) {
+export function PlannedExpenseItemCard({
+  detail,
+  depth,
+  categories,
+  editing,
+  table,
+  utils,
+  isFocused = false,
+  rowRef
+}: PlannedExpenseItemCardProps) {
   const {
     editingItemId,
     editDraft,
@@ -113,12 +124,16 @@ export function PlannedExpenseItemCard({ detail, depth, categories, editing, tab
 
   const indentationStyle = { paddingLeft: depth * 20 };
 
+  const rowToneClass = isEditing
+    ? 'bg-slate-950/60 ring-1 ring-inset ring-accent/40'
+    : isFocused
+    ? 'bg-slate-900/60 ring-1 ring-inset ring-accent/30'
+    : 'bg-slate-950/25 hover:bg-slate-900/55';
+
   return (
     <div
-      key={detail.item.id}
-      className={`group/row grid items-start gap-4 border-t border-slate-800/60 px-4 py-3 text-[11px] sm:text-xs transition ${
-        isEditing ? 'bg-slate-950/60 ring-1 ring-inset ring-accent/40' : 'bg-slate-950/25 hover:bg-slate-900/55'
-      }`}
+      ref={rowRef}
+      className={`group/row grid items-start gap-4 border-t border-slate-800/60 px-4 py-3 text-[11px] sm:text-xs transition ${rowToneClass}`}
       style={{ gridTemplateColumns: table.gridTemplateColumns }}
     >
       {table.visibleColumns.map((column) => {

--- a/src/features/smart-budgeting/organisms/CategoryNavigator.tsx
+++ b/src/features/smart-budgeting/organisms/CategoryNavigator.tsx
@@ -1,26 +1,10 @@
-import { Fragment } from 'react';
-import type { JSX } from 'react';
+import { useEffect, useRef } from 'react';
 import { PlannedExpenseItemCard } from '../molecules/PlannedExpenseItemCard';
 import type {
-  CategoryNode,
   PlannedExpenseDetail,
   SmartBudgetingColumnKey,
   SmartBudgetingController
 } from '../hooks/useSmartBudgetingController';
-
-const CalendarIcon = ({ className = 'h-4 w-4' }: { className?: string }): JSX.Element => (
-  <svg viewBox="0 0 20 20" className={className} aria-hidden>
-    <rect x="3" y="5" width="14" height="11" rx="1.5" fill="none" stroke="currentColor" strokeWidth="1.4" />
-    <path d="M3 8.5h14" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
-    <path d="M7 3v2.5m6-2.5V5.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
-  </svg>
-);
-
-const ChevronRightIcon = ({ className = 'h-3.5 w-3.5' }: { className?: string }): JSX.Element => (
-  <svg viewBox="0 0 20 20" className={className} aria-hidden>
-    <path d="m7 5 5 5-5 5" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
-  </svg>
-);
 
 interface CategoryNavigatorProps {
   categories: SmartBudgetingController['categories'];
@@ -31,22 +15,14 @@ interface CategoryNavigatorProps {
 
 export function CategoryNavigator({ categories, editing, table, utils }: CategoryNavigatorProps) {
   const {
-    tree,
-    expanded,
-    toggleCategory,
-    categorySummaries,
-    itemsByCategory,
-    expenseDescendantsMap,
-    normalisedSearchTerm,
-    navigatorFilter,
-    focusCategory,
-    visibleUncategorisedDetails,
+    visibleNavigatorDetails,
     navigatorView,
     priorityGroups,
     hasNavigatorResults,
-    renderedCategories
+    focusedDetailId
   } = categories;
   const { visibleColumns, gridTemplateColumns } = table;
+
   const columnLabels: Record<SmartBudgetingColumnKey, string> = {
     category: 'Category / Planned items',
     earliestDue: 'Earliest due',
@@ -56,206 +32,67 @@ export function CategoryNavigator({ categories, editing, table, utils }: Categor
     actions: 'Actions'
   } as const;
 
-  const renderCategorySection = (category: CategoryNode, depth = 0): JSX.Element | null => {
-    const summary = categorySummaries.get(category.id) ?? {
-      planned: 0,
-      actual: 0,
-      variance: 0,
-      itemCount: 0,
-      remainder: 0
-    };
-    const directItems = itemsByCategory.get(category.id) ?? [];
-    const categoryStatus = summary.actual === 0 ? 'not-spent' : summary.variance >= 0 ? 'under' : 'over';
-    const statusToken = utils.SPENDING_BADGE_STYLES[categoryStatus];
-    const descendantIds = expenseDescendantsMap.get(category.id) ?? new Set<string>([category.id]);
-    const remainderValue = summary.remainder;
-    const remainderClass = remainderValue >= 0 ? 'text-success' : 'text-danger';
-    const remainderLabel = remainderValue >= 0 ? 'Remaining' : 'Overspent';
-    const remainderDescriptor = summary.actual === 0 && remainderValue >= 0 ? 'Awaiting spend' : remainderLabel;
-    const nextDueDetail = categories.visibleCategoryDetails.reduce<PlannedExpenseDetail | null>((closest, detail) => {
-      if (!descendantIds.has(detail.item.categoryId) || !detail.item.dueDate) {
-        return closest;
-      }
-      if (!closest || !closest.item.dueDate) return detail;
-      const currentTime = new Date(detail.item.dueDate).getTime();
-      const closestTime = new Date(closest.item.dueDate).getTime();
-      return currentTime < closestTime ? detail : closest;
-    }, null);
-    const nextDueLabel =
-      nextDueDetail && nextDueDetail.item.dueDate
-        ? new Date(nextDueDetail.item.dueDate).toLocaleDateString('en-IN', {
-            month: 'short',
-            day: 'numeric'
-          })
-        : null;
-    const dueDisplayLabel = nextDueLabel ?? 'No due dates';
-    const dueTextClass = nextDueLabel ? 'text-slate-100' : 'text-slate-500';
-    const dueIconClass = nextDueLabel ? 'text-slate-400' : 'text-slate-700';
-    const matchesCategorySearch =
-      normalisedSearchTerm !== '' && category.name.toLowerCase().includes(normalisedSearchTerm);
-    const visibleDirectItems = directItems.filter((detail) => {
-      const matchesStatus = navigatorFilter === 'all' || detail.status === navigatorFilter;
-      const matchesName =
-        normalisedSearchTerm === '' ||
-        detail.item.name.toLowerCase().includes(normalisedSearchTerm) ||
-        matchesCategorySearch;
-      return matchesStatus && matchesName;
-    });
-    const childSections = category.children
-      .map((child) => renderCategorySection(child, depth + 1))
-      .filter((child): child is JSX.Element => child !== null);
-    const hasVisibleItems = visibleDirectItems.length > 0;
-    const hasVisibleChildren = childSections.length > 0;
-    const canExpand = hasVisibleItems || hasVisibleChildren;
-    const matchesStatusForCategory = navigatorFilter === 'all' || categoryStatus === navigatorFilter;
+  const itemRefs = useRef(new Map<string, HTMLDivElement>());
 
-    if (!matchesStatusForCategory && !hasVisibleItems && !hasVisibleChildren && !matchesCategorySearch) {
-      return null;
+  useEffect(() => {
+    if (navigatorView !== 'category' || !focusedDetailId) {
+      return;
     }
+    const element = itemRefs.current.get(focusedDetailId);
+    if (element) {
+      element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, [focusedDetailId, navigatorView, visibleNavigatorDetails]);
 
-    const isFocused = categories.focusedCategoryId === category.id;
-    const shouldAutoExpand =
-      normalisedSearchTerm !== '' && (matchesCategorySearch || hasVisibleItems || hasVisibleChildren);
-    const isExpanded = canExpand && (shouldAutoExpand || Boolean(expanded[category.id]));
-    const focusClass = isFocused ? 'bg-slate-900/60 ring-1 ring-inset ring-accent/40' : 'bg-slate-950/30 hover:bg-slate-900/50';
-    const dimClass =
-      normalisedSearchTerm !== '' && !matchesCategorySearch && !hasVisibleItems && !hasVisibleChildren
-        ? 'opacity-70'
-        : '';
-    const handleToggle = () => {
-      focusCategory(category.id);
-      if (canExpand) {
-        toggleCategory(category.id);
-      }
-    };
-    const indentation = depth * 20;
-
-    return (
-      <div key={category.id} className={dimClass}>
-        <div
-          onClick={() => focusCategory(category.id, true)}
-          className={`grid cursor-pointer items-center gap-4 border-t border-slate-800/70 px-4 py-3 text-[11px] sm:text-xs transition ${focusClass}`}
-          style={{ gridTemplateColumns }}
-        >
-          {visibleColumns.map((column) => {
-            if (column === 'category') {
-              return (
-                <div
-                  key={`${category.id}-${column}`}
-                  className="flex min-w-0 items-center gap-3"
-                  style={{ paddingLeft: indentation }}
-                >
-                  <button
-                    type="button"
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      handleToggle();
-                    }}
-                    aria-expanded={Boolean(isExpanded)}
-                    aria-disabled={!canExpand}
-                    className={`flex h-6 w-6 items-center justify-center rounded-md border border-slate-700 bg-slate-950/60 text-slate-400 transition ${
-                      canExpand ? 'hover:border-accent hover:text-accent' : 'cursor-default opacity-40'
-                    }`}
-                  >
-                    {canExpand ? (
-                      <span
-                        aria-hidden
-                        className={`flex items-center justify-center transition-transform ${isExpanded ? 'rotate-90' : ''}`}
-                      >
-                        <ChevronRightIcon />
-                      </span>
-                    ) : (
-                      <span aria-hidden className="block h-1.5 w-1.5 rounded-full bg-current" />
-                    )}
-                    <span className="sr-only">
-                      {canExpand ? (isExpanded ? 'Collapse category' : 'Expand category') : 'No nested items'}
-                    </span>
-                  </button>
-                  <div className="min-w-0 space-y-1">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <p className="truncate text-sm font-semibold text-slate-100">{category.name}</p>
-                      <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${statusToken.badgeClass}`}>
-                        {statusToken.label}
-                      </span>
-                    </div>
-                    <div className="flex flex-wrap items-center gap-2 text-[10px] text-slate-500">
-                      <span>{summary.itemCount} planned item{summary.itemCount === 1 ? '' : 's'}</span>
-                      {nextDueLabel && <span>Next due {nextDueLabel}</span>}
-                    </div>
-                  </div>
-                </div>
-              );
-            }
-            if (column === 'earliestDue') {
-              return (
-                <div key={`${category.id}-${column}`} className="flex items-center justify-end gap-2 text-xs text-slate-300">
-                  <CalendarIcon className={`h-4 w-4 ${dueIconClass}`} />
-                  <span className={`whitespace-nowrap text-sm font-semibold ${dueTextClass}`}>{dueDisplayLabel}</span>
-                </div>
-              );
-            }
-            if (column === 'planned') {
-              return (
-                <div
-                  key={`${category.id}-${column}`}
-                  className="whitespace-nowrap text-right text-sm font-semibold text-warning"
-                >
-                  {utils.formatCurrency(summary.planned)}
-                </div>
-              );
-            }
-            if (column === 'actual') {
-              return (
-                <div
-                  key={`${category.id}-${column}`}
-                  className="whitespace-nowrap text-right text-sm font-semibold text-slate-200"
-                >
-                  {utils.formatCurrency(summary.actual)}
-                </div>
-              );
-            }
-            if (column === 'variance') {
-              return (
-                <div
-                  key={`${category.id}-${column}`}
-                  className="flex flex-nowrap items-center justify-end gap-2 text-right"
-                >
-                  <span className={`whitespace-nowrap text-sm font-semibold ${remainderClass}`}>
-                    {utils.formatCurrency(summary.variance)}
-                  </span>
-                  <span className="whitespace-nowrap rounded-full bg-slate-900/40 px-2 py-0.5 text-[10px] text-slate-400">
-                    {remainderDescriptor}
-                  </span>
-                </div>
-              );
-            }
-            return <div key={`${category.id}-${column}`} className="flex items-center justify-end" />;
-          })}
-        </div>
-        {isExpanded && (
-          <div className="bg-slate-950/15">
-            {visibleDirectItems.length > 0 &&
-              visibleDirectItems.map((item) => (
-                <PlannedExpenseItemCard
-                  key={item.item.id}
-                  detail={item}
-                  depth={depth + 1}
-                  categories={categories}
-                  editing={editing}
-                  table={table}
-                  utils={utils}
-                />
-              ))}
-            {childSections}
-          </div>
-        )}
-      </div>
-    );
+  const captureRowRef = (detailId: string) => (element: HTMLDivElement | null) => {
+    if (element) {
+      itemRefs.current.set(detailId, element);
+    } else {
+      itemRefs.current.delete(detailId);
+    }
   };
 
-  const categorySections = renderedCategories
-    .map((category) => renderCategorySection(category))
-    .filter((section): section is JSX.Element => section !== null);
+  const renderDetailRow = (detail: PlannedExpenseDetail) => (
+    <PlannedExpenseItemCard
+      key={detail.item.id}
+      detail={detail}
+      depth={0}
+      categories={categories}
+      editing={editing}
+      table={table}
+      utils={utils}
+      isFocused={focusedDetailId === detail.item.id}
+      rowRef={captureRowRef(detail.item.id)}
+    />
+  );
+
+  const categoryView = (
+    <div className="overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-950/40 shadow-inner">
+      <div className="overflow-x-auto">
+        <div className="min-w-[980px] text-xs">
+          <div
+            className="grid items-center gap-4 border-b border-slate-800/80 bg-slate-950 px-4 py-3 text-[11px] font-semibold uppercase tracking-wide text-slate-400"
+            style={{ gridTemplateColumns }}
+          >
+            {visibleColumns.map((column) => (
+              <span key={`header-${column}`} className={column === 'category' ? '' : 'text-right'}>
+                {columnLabels[column]}
+              </span>
+            ))}
+          </div>
+          <div>
+            {visibleNavigatorDetails.length > 0 ? (
+              visibleNavigatorDetails.map((detail) => renderDetailRow(detail))
+            ) : (
+              <div className="px-4 py-6 text-center text-xs text-slate-500">
+                No planned expenses match the current filters.
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 
   const prioritySection = (
     <div className="space-y-4">
@@ -278,6 +115,7 @@ export function CategoryNavigator({ categories, editing, table, utils }: Categor
                     editing={editing}
                     table={table}
                     utils={utils}
+                    isFocused={focusedDetailId === detail.item.id}
                   />
                 ))}
               </div>
@@ -290,27 +128,6 @@ export function CategoryNavigator({ categories, editing, table, utils }: Categor
     </div>
   );
 
-  const uncategorisedSection = visibleUncategorisedDetails.length > 0 && (
-    <div className="rounded-2xl border border-slate-800/70 bg-slate-950/40">
-      <div className="border-b border-slate-800/80 px-4 py-3 text-[11px] font-semibold uppercase tracking-wide text-slate-400">
-        Uncategorised items
-      </div>
-      <div>
-        {visibleUncategorisedDetails.map((detail) => (
-          <PlannedExpenseItemCard
-            key={detail.item.id}
-            detail={detail}
-            depth={0}
-            categories={categories}
-            editing={editing}
-            table={table}
-            utils={utils}
-          />
-        ))}
-      </div>
-    </div>
-  );
-
   if (!hasNavigatorResults) {
     return (
       <div className="rounded-lg border border-slate-800 bg-slate-950/70 p-6 text-center text-sm text-slate-500">
@@ -319,34 +136,5 @@ export function CategoryNavigator({ categories, editing, table, utils }: Categor
     );
   }
 
-  return (
-    <section className="space-y-4">
-      {navigatorView === 'category' ? (
-        <Fragment>
-          {categorySections.length > 0 && (
-            <div className="overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-950/40 shadow-inner">
-              <div className="overflow-x-auto">
-                <div className="min-w-[980px] text-xs">
-                  <div
-                    className="grid items-center gap-4 border-b border-slate-800/80 bg-slate-950 px-4 py-3 text-[11px] font-semibold uppercase tracking-wide text-slate-400"
-                    style={{ gridTemplateColumns }}
-                  >
-                    {visibleColumns.map((column) => (
-                      <span key={`header-${column}`} className={column === 'category' ? '' : 'text-right'}>
-                        {columnLabels[column]}
-                      </span>
-                    ))}
-                  </div>
-                  <div>{categorySections}</div>
-                </div>
-              </div>
-            </div>
-          )}
-          {uncategorisedSection}
-        </Fragment>
-      ) : (
-        prioritySection
-      )}
-    </section>
-  );
+  return <section className="space-y-4">{navigatorView === 'category' ? categoryView : prioritySection}</section>;
 }

--- a/src/features/smart-budgeting/organisms/NavigatorFilters.tsx
+++ b/src/features/smart-budgeting/organisms/NavigatorFilters.tsx
@@ -6,8 +6,6 @@ interface NavigatorFiltersProps {
   categories: SmartBudgetingController['categories'];
   table: SmartBudgetingController['table'];
   onOpenDialog: () => void;
-  onExpandAll: () => void;
-  onCollapseAll: () => void;
 }
 
 const statusIcons: Record<'all' | 'over' | 'under' | 'not-spent', JSX.Element> = {
@@ -98,7 +96,7 @@ const resetIcon = (
   </svg>
 );
 
-export function NavigatorFilters({ categories, table, onOpenDialog, onExpandAll, onCollapseAll }: NavigatorFiltersProps) {
+export function NavigatorFilters({ categories, table, onOpenDialog }: NavigatorFiltersProps) {
   const {
     navigatorFilter,
     setNavigatorFilter,
@@ -190,44 +188,6 @@ export function NavigatorFilters({ categories, table, onOpenDialog, onExpandAll,
             className="inline-flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-accent/90"
           >
             + Plan expenses
-          </button>
-          <button
-            type="button"
-            onClick={onExpandAll}
-            aria-label="Expand all"
-            className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-slate-700 text-slate-300 transition hover:border-slate-500 hover:text-accent"
-          >
-            <svg
-              aria-hidden="true"
-              className="h-4 w-4"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M12 5v14M5 12h14" />
-            </svg>
-          </button>
-          <button
-            type="button"
-            onClick={onCollapseAll}
-            aria-label="Collapse all"
-            className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-slate-700 text-slate-300 transition hover:border-slate-500 hover:text-accent"
-          >
-            <svg
-              aria-hidden="true"
-              className="h-4 w-4"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M5 12h14" />
-            </svg>
           </button>
           <details className="relative">
             <summary

--- a/src/features/smart-budgeting/organisms/SummaryGrid.tsx
+++ b/src/features/smart-budgeting/organisms/SummaryGrid.tsx
@@ -169,7 +169,7 @@ export function SummaryGrid({ overview, categories, utils }: SummaryGridProps) {
         {selectedCategoryId !== 'all' && (
           <button
             type="button"
-            onClick={() => focusCategory(selectedCategoryId, true)}
+            onClick={() => focusCategory(selectedCategoryId)}
             className="mt-3 text-[11px] font-semibold text-accent hover:text-accent/80"
           >
             Focus in navigator
@@ -194,7 +194,7 @@ export function SummaryGrid({ overview, categories, utils }: SummaryGridProps) {
                   <button
                     type="button"
                     onClick={() => {
-                      focusCategory(category.id, true);
+                      focusCategory(category.id);
                       categories.handleSummaryScopeChange(category.id);
                     }}
                     className="font-semibold text-danger hover:underline"

--- a/src/views/SmartBudgetingView.tsx
+++ b/src/views/SmartBudgetingView.tsx
@@ -32,8 +32,6 @@ export function SmartBudgetingView() {
         categories={categories}
         table={table}
         onOpenDialog={dialog.open}
-        onExpandAll={categories.expandAllCategories}
-        onCollapseAll={categories.collapseAllCategories}
       />
 
       <CategoryNavigator categories={categories} editing={editing} table={table} utils={utils} />


### PR DESCRIPTION
## Summary
- add focused planned-expense tracking in the smart budgeting controller and derive flattened navigator data
- simplify the category navigator to a flat list that highlights and scrolls to the focused item
- remove tree-expansion hooks from filters and summary interactions now that the navigator is flat

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e27d7a34c4832cb3f9b227fa8cda6e