### PR TITLE
Remove duplicate totals from monthly overview header

### DIFF
--- a/src/features/smart-budgeting/organisms/SummaryGrid.tsx
+++ b/src/features/smart-budgeting/organisms/SummaryGrid.tsx
@@ -59,29 +59,6 @@ export function SummaryGrid({ overview, categories, utils }: SummaryGridProps) {
           <div>
             <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">{summaryPeriodLabel} overview</p>
             <p className="mt-1 text-lg font-semibold text-slate-100">{periodLabel}</p>
-            <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-slate-400">
-              <span>
-                Planned:{' '}
-                <span className="font-semibold text-slate-100">
-                  {utils.formatCurrency(overallSummary.planned)}
-                </span>
-              </span>
-              <span>
-                Spent:{' '}
-                <span className="font-semibold text-slate-100">
-                  {utils.formatCurrency(overallSummary.actual)}
-                </span>
-              </span>
-              <span>
-                Remaining:{' '}
-                <span className={`font-semibold ${remaining >= 0 ? 'text-success' : 'text-danger'}`}>
-                  {utils.formatCurrency(remaining)}
-                </span>{' '}
-                <span className="text-slate-500">
-                  ({remainingPercent}% {remainingDescriptor})
-                </span>
-              </span>
-            </div>
           </div>
           <span className={`rounded-full px-2 py-1 text-[10px] font-semibold ${overallStatusToken.badgeClass}`}>
             {overallStatusToken.label}


### PR DESCRIPTION
## Summary
- remove the inline planned/spent/remaining summary from the monthly overview header to avoid duplication with the card data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e29b02ac88832ca4567b2f45f0e89f