### PR TITLE
Flatten smart budgeting navigator table

### DIFF
--- a/src/features/smart-budgeting/organisms/CategoryNavigator.tsx
+++ b/src/features/smart-budgeting/organisms/CategoryNavigator.tsx
@@ -2,7 +2,6 @@ import { Fragment } from 'react';
 import type { JSX } from 'react';
 import { PlannedExpenseItemCard } from '../molecules/PlannedExpenseItemCard';
 import type {
-  CategoryNode,
   PlannedExpenseDetail,
   SmartBudgetingColumnKey,
   SmartBudgetingController
@@ -16,12 +15,6 @@ const CalendarIcon = ({ className = 'h-4 w-4' }: { className?: string }): JSX.El
   </svg>
 );
 
-const ChevronRightIcon = ({ className = 'h-3.5 w-3.5' }: { className?: string }): JSX.Element => (
-  <svg viewBox="0 0 20 20" className={className} aria-hidden>
-    <path d="m7 5 5 5-5 5" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
-  </svg>
-);
-
 interface CategoryNavigatorProps {
   categories: SmartBudgetingController['categories'];
   editing: SmartBudgetingController['editing'];
@@ -31,20 +24,12 @@ interface CategoryNavigatorProps {
 
 export function CategoryNavigator({ categories, editing, table, utils }: CategoryNavigatorProps) {
   const {
-    tree,
-    expanded,
-    toggleCategory,
-    categorySummaries,
-    itemsByCategory,
-    expenseDescendantsMap,
-    normalisedSearchTerm,
-    navigatorFilter,
-    focusCategory,
+    lookup: categoryLookup,
+    visibleCategoryDetails,
     visibleUncategorisedDetails,
     navigatorView,
     priorityGroups,
-    hasNavigatorResults,
-    renderedCategories
+    hasNavigatorResults
   } = categories;
   const { visibleColumns, gridTemplateColumns } = table;
   const columnLabels: Record<SmartBudgetingColumnKey, string> = {
@@ -67,222 +52,6 @@ export function CategoryNavigator({ categories, editing, table, utils }: Categor
     status: 'text-left',
     priority: 'text-left'
   };
-
-  const renderCategorySection = (category: CategoryNode, depth = 0): JSX.Element | null => {
-    const summary = categorySummaries.get(category.id) ?? {
-      planned: 0,
-      actual: 0,
-      variance: 0,
-      itemCount: 0,
-      remainder: 0
-    };
-    const directItems = itemsByCategory.get(category.id) ?? [];
-    const categoryStatus = summary.actual === 0 ? 'not-spent' : summary.variance >= 0 ? 'under' : 'over';
-    const statusToken = utils.SPENDING_BADGE_STYLES[categoryStatus];
-    const descendantIds = expenseDescendantsMap.get(category.id) ?? new Set<string>([category.id]);
-    const remainderValue = summary.remainder;
-    const remainderClass = remainderValue >= 0 ? 'text-success' : 'text-danger';
-    const remainderLabel = remainderValue >= 0 ? 'Remaining' : 'Overspent';
-    const remainderDescriptor = summary.actual === 0 && remainderValue >= 0 ? 'Awaiting spend' : remainderLabel;
-    const nextDueDetail = categories.visibleCategoryDetails.reduce<PlannedExpenseDetail | null>((closest, detail) => {
-      if (!descendantIds.has(detail.item.categoryId) || !detail.item.dueDate) {
-        return closest;
-      }
-      if (!closest || !closest.item.dueDate) return detail;
-      const currentTime = new Date(detail.item.dueDate).getTime();
-      const closestTime = new Date(closest.item.dueDate).getTime();
-      return currentTime < closestTime ? detail : closest;
-    }, null);
-    const nextDueLabel =
-      nextDueDetail && nextDueDetail.item.dueDate
-        ? new Date(nextDueDetail.item.dueDate).toLocaleDateString('en-IN', {
-            month: 'short',
-            day: 'numeric'
-          })
-        : null;
-    const dueDisplayLabel = nextDueLabel ?? 'No due dates';
-    const dueTextClass = nextDueLabel ? 'text-slate-100' : 'text-slate-500';
-    const dueIconClass = nextDueLabel ? 'text-slate-400' : 'text-slate-700';
-    const matchesCategorySearch =
-      normalisedSearchTerm !== '' && category.name.toLowerCase().includes(normalisedSearchTerm);
-    const visibleDirectItems = directItems.filter((detail) => {
-      const matchesStatus = navigatorFilter === 'all' || detail.status === navigatorFilter;
-      const matchesName =
-        normalisedSearchTerm === '' ||
-        detail.item.name.toLowerCase().includes(normalisedSearchTerm) ||
-        matchesCategorySearch;
-      return matchesStatus && matchesName;
-    });
-    const childSections = category.children
-      .map((child) => renderCategorySection(child, depth + 1))
-      .filter((child): child is JSX.Element => child !== null);
-    const hasVisibleItems = visibleDirectItems.length > 0;
-    const hasVisibleChildren = childSections.length > 0;
-    const canExpand = hasVisibleItems || hasVisibleChildren;
-    const matchesStatusForCategory = navigatorFilter === 'all' || categoryStatus === navigatorFilter;
-
-    if (!matchesStatusForCategory && !hasVisibleItems && !hasVisibleChildren && !matchesCategorySearch) {
-      return null;
-    }
-
-    const isFocused = categories.focusedCategoryId === category.id;
-    const shouldAutoExpand =
-      normalisedSearchTerm !== '' && (matchesCategorySearch || hasVisibleItems || hasVisibleChildren);
-    const isExpanded = canExpand && (shouldAutoExpand || Boolean(expanded[category.id]));
-    const focusClass = isFocused ? 'bg-slate-900/60 ring-1 ring-inset ring-accent/40' : 'bg-slate-950/30 hover:bg-slate-900/50';
-    const dimClass =
-      normalisedSearchTerm !== '' && !matchesCategorySearch && !hasVisibleItems && !hasVisibleChildren
-        ? 'opacity-70'
-        : '';
-    const handleToggle = () => {
-      focusCategory(category.id);
-      if (canExpand) {
-        toggleCategory(category.id);
-      }
-    };
-    const indentation = depth * 20;
-
-    return (
-      <div key={category.id} className={dimClass}>
-        <div
-          onClick={() => focusCategory(category.id, true)}
-          className={`grid cursor-pointer items-center gap-4 border-t border-slate-800/70 px-4 py-3 text-[11px] sm:text-xs transition ${focusClass}`}
-          style={{ gridTemplateColumns }}
-        >
-          {visibleColumns.map((column) => {
-            switch (column) {
-              case 'category':
-                return (
-                  <div
-                    key={`${category.id}-${column}`}
-                    className="flex min-w-0 items-center gap-3"
-                    style={{ paddingLeft: indentation }}
-                  >
-                    <button
-                      type="button"
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        handleToggle();
-                      }}
-                      aria-expanded={Boolean(isExpanded)}
-                      aria-disabled={!canExpand}
-                      className={`flex h-6 w-6 items-center justify-center rounded-md border border-slate-700 bg-slate-950/60 text-slate-400 transition ${
-                        canExpand ? 'hover:border-accent hover:text-accent' : 'cursor-default opacity-40'
-                      }`}
-                    >
-                      {canExpand ? (
-                        <span
-                          aria-hidden
-                          className={`flex items-center justify-center transition-transform ${isExpanded ? 'rotate-90' : ''}`}
-                        >
-                          <ChevronRightIcon />
-                        </span>
-                      ) : (
-                        <span aria-hidden className="block h-1.5 w-1.5 rounded-full bg-current" />
-                      )}
-                      <span className="sr-only">
-                        {canExpand ? (isExpanded ? 'Collapse category' : 'Expand category') : 'No nested items'}
-                      </span>
-                    </button>
-                    <div className="min-w-0">
-                      <p className="truncate text-sm font-semibold text-slate-100">{category.name}</p>
-                    </div>
-                  </div>
-                );
-              case 'item':
-                return (
-                  <div key={`${category.id}-${column}`} className="min-w-0 space-y-1 text-xs text-slate-400">
-                    <p>
-                      {summary.itemCount} planned item{summary.itemCount === 1 ? '' : 's'}
-                    </p>
-                    <p className={nextDueLabel ? 'text-slate-500' : 'text-slate-600'}>
-                      {nextDueLabel ? `Next due ${nextDueLabel}` : 'No upcoming due dates'}
-                    </p>
-                  </div>
-                );
-              case 'planned':
-                return (
-                  <div
-                    key={`${category.id}-${column}`}
-                    className="whitespace-nowrap text-right text-sm font-semibold text-warning"
-                  >
-                    {utils.formatCurrency(summary.planned)}
-                  </div>
-                );
-              case 'actual':
-                return (
-                  <div
-                    key={`${category.id}-${column}`}
-                    className="whitespace-nowrap text-right text-sm font-semibold text-slate-200"
-                  >
-                    {utils.formatCurrency(summary.actual)}
-                  </div>
-                );
-              case 'variance':
-                return (
-                  <div
-                    key={`${category.id}-${column}`}
-                    className="flex flex-nowrap items-center justify-end gap-2 text-right"
-                  >
-                    <span className={`whitespace-nowrap text-sm font-semibold ${remainderClass}`}>
-                      {utils.formatCurrency(summary.variance)}
-                    </span>
-                    <span className="whitespace-nowrap rounded-full bg-slate-900/40 px-2 py-0.5 text-[10px] text-slate-400">
-                      {remainderDescriptor}
-                    </span>
-                  </div>
-                );
-              case 'due':
-                return (
-                  <div key={`${category.id}-${column}`} className="flex items-center gap-2 text-xs text-slate-300">
-                    <CalendarIcon className={`h-4 w-4 ${dueIconClass}`} />
-                    <span className={`whitespace-nowrap text-sm font-semibold ${dueTextClass}`}>{dueDisplayLabel}</span>
-                  </div>
-                );
-              case 'status':
-                return (
-                  <div key={`${category.id}-${column}`} className="flex flex-wrap items-center gap-2 text-[10px]">
-                    <span className={`rounded-full px-2 py-0.5 font-semibold ${statusToken.badgeClass}`}>
-                      {statusToken.label}
-                    </span>
-                    <span className="text-slate-400">{remainderDescriptor}</span>
-                  </div>
-                );
-              case 'priority':
-                return (
-                  <div key={`${category.id}-${column}`} className="text-sm text-slate-600">
-                    —
-                  </div>
-                );
-              default:
-                return null;
-            }
-          })}
-        </div>
-        {isExpanded && (
-          <div className="bg-slate-950/15">
-            {visibleDirectItems.length > 0 &&
-              visibleDirectItems.map((item) => (
-                <PlannedExpenseItemCard
-                  key={item.item.id}
-                  detail={item}
-                  depth={depth + 1}
-                  categories={categories}
-                  editing={editing}
-                  table={table}
-                  utils={utils}
-                />
-              ))}
-            {childSections}
-          </div>
-        )}
-      </div>
-    );
-  };
-
-  const categorySections = renderedCategories
-    .map((category) => renderCategorySection(category))
-    .filter((section): section is JSX.Element => section !== null);
 
   const prioritySection = (
     <div className="space-y-4">
@@ -338,6 +107,24 @@ export function CategoryNavigator({ categories, editing, table, utils }: Categor
     </div>
   );
 
+  const renderRemainderDescriptor = (detail: PlannedExpenseDetail) => {
+    if (detail.actual === 0 && detail.remainder >= 0) {
+      return 'Awaiting spend';
+    }
+    return detail.remainder >= 0 ? 'Remaining' : 'Overspent';
+  };
+
+  const renderDueDisplay = (detail: PlannedExpenseDetail) => {
+    if (!detail.item.dueDate) {
+      return { label: 'No due dates', muted: true };
+    }
+    const label = new Date(detail.item.dueDate).toLocaleDateString('en-IN', {
+      month: 'short',
+      day: 'numeric'
+    });
+    return { label, muted: false };
+  };
+
   if (!hasNavigatorResults) {
     return (
       <div className="rounded-lg border border-slate-800 bg-slate-950/70 p-6 text-center text-sm text-slate-500">
@@ -350,7 +137,7 @@ export function CategoryNavigator({ categories, editing, table, utils }: Categor
     <section className="space-y-4">
       {navigatorView === 'category' ? (
         <Fragment>
-          {categorySections.length > 0 && (
+          {visibleCategoryDetails.length > 0 && (
             <div className="overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-950/40 shadow-inner">
               <div className="overflow-x-auto">
                 <div className="min-w-[980px] text-xs">
@@ -364,7 +151,116 @@ export function CategoryNavigator({ categories, editing, table, utils }: Categor
                       </span>
                     ))}
                   </div>
-                  <div>{categorySections}</div>
+                  <div>
+                    {visibleCategoryDetails.map((detail) => {
+                      const category = categoryLookup.get(detail.item.categoryId);
+                      const categoryLabel = category?.name ?? 'Uncategorised';
+                      const remainderDescriptor = renderRemainderDescriptor(detail);
+                      const remainderClass = detail.remainder >= 0 ? 'text-success' : 'text-danger';
+                      const dueDisplay = renderDueDisplay(detail);
+                      const statusToken = utils.SPENDING_BADGE_STYLES[detail.status];
+                      const priorityToken = utils.PRIORITY_TOKEN_STYLES[detail.priority];
+
+                      return (
+                        <div
+                          key={detail.item.id}
+                          className="grid items-center gap-4 border-t border-slate-800/70 px-4 py-3 text-[11px] sm:text-xs"
+                          style={{ gridTemplateColumns }}
+                        >
+                          {visibleColumns.map((column) => {
+                            switch (column) {
+                              case 'category':
+                                return (
+                                  <div key={`${detail.item.id}-${column}`} className="min-w-0">
+                                    <p className="truncate text-sm font-semibold text-slate-100">{categoryLabel}</p>
+                                  </div>
+                                );
+                              case 'item':
+                                return (
+                                  <div key={`${detail.item.id}-${column}`} className="min-w-0">
+                                    <p className="truncate text-sm font-semibold text-slate-200">{detail.item.name}</p>
+                                    <p className="truncate text-[10px] text-slate-500">{remainderDescriptor}</p>
+                                  </div>
+                                );
+                              case 'planned':
+                                return (
+                                  <div
+                                    key={`${detail.item.id}-${column}`}
+                                    className="whitespace-nowrap text-right text-sm font-semibold text-warning"
+                                  >
+                                    {utils.formatCurrency(detail.item.plannedAmount)}
+                                  </div>
+                                );
+                              case 'actual':
+                                return (
+                                  <div
+                                    key={`${detail.item.id}-${column}`}
+                                    className="whitespace-nowrap text-right text-sm font-semibold text-slate-200"
+                                  >
+                                    {utils.formatCurrency(detail.actual)}
+                                  </div>
+                                );
+                              case 'variance':
+                                return (
+                                  <div
+                                    key={`${detail.item.id}-${column}`}
+                                    className="flex flex-nowrap items-center justify-end gap-2 text-right"
+                                  >
+                                    <span className={`whitespace-nowrap text-sm font-semibold ${remainderClass}`}>
+                                      {utils.formatCurrency(detail.variance)}
+                                    </span>
+                                    <span className="whitespace-nowrap rounded-full bg-slate-900/40 px-2 py-0.5 text-[10px] text-slate-400">
+                                      {remainderDescriptor}
+                                    </span>
+                                  </div>
+                                );
+                              case 'due':
+                                return (
+                                  <div
+                                    key={`${detail.item.id}-${column}`}
+                                    className="flex items-center gap-2 text-xs text-slate-300"
+                                  >
+                                    <CalendarIcon className={`h-4 w-4 ${dueDisplay.muted ? 'text-slate-700' : 'text-slate-400'}`} />
+                                    <span
+                                      className={`whitespace-nowrap text-sm font-semibold ${
+                                        dueDisplay.muted ? 'text-slate-500' : 'text-slate-100'
+                                      }`}
+                                    >
+                                      {dueDisplay.label}
+                                    </span>
+                                  </div>
+                                );
+                              case 'status':
+                                return (
+                                  <div
+                                    key={`${detail.item.id}-${column}`}
+                                    className="flex flex-wrap items-center gap-2 text-[10px]"
+                                  >
+                                    <span className={`rounded-full px-2 py-0.5 font-semibold ${statusToken.badgeClass}`}>
+                                      {statusToken.label}
+                                    </span>
+                                    <span className="text-slate-400">{remainderDescriptor}</span>
+                                  </div>
+                                );
+                              case 'priority':
+                                return (
+                                  <div
+                                    key={`${detail.item.id}-${column}`}
+                                    className="flex items-center gap-2 text-[10px] text-slate-200"
+                                  >
+                                    <span className={`rounded-full px-2 py-0.5 font-semibold ${priorityToken.badgeClass}`}>
+                                      {priorityToken.label}
+                                    </span>
+                                  </div>
+                                );
+                              default:
+                                return null;
+                            }
+                          })}
+                        </div>
+                      );
+                    })}
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- replace the category accordion with a flattened grid of planned expense rows
- drive each row directly from the normalised planned expense details in the store so totals stay in sync
- retain priority and uncategorised panels alongside the streamlined table presentation

## Testing
- npm run lint *(fails: ESLint configuration missing in project)*

------
https://chatgpt.com/codex/tasks/task_e_68e29a25dff4832c9e150d5f08fd9cf1