### PR TITLE
Enable resizable smart budgeting columns

### DIFF
--- a/src/features/smart-budgeting/hooks/useSmartBudgetingController.tsx
+++ b/src/features/smart-budgeting/hooks/useSmartBudgetingController.tsx
@@ -82,14 +82,62 @@ export type SmartBudgetingColumnKey =
   | 'status'
   | 'priority';
 
+const COLUMN_KEYS = [
+  'category',
+  'item',
+  'planned',
+  'actual',
+  'variance',
+  'due',
+  'status',
+  'priority'
+] as const satisfies SmartBudgetingColumnKey[];
+
 type ColumnPreferences = {
   order: SmartBudgetingColumnKey[];
   visible: Record<SmartBudgetingColumnKey, boolean>;
   widths: Record<SmartBudgetingColumnKey, string>;
 };
 
+const COLUMN_MIN_WIDTHS: Record<SmartBudgetingColumnKey, number> = {
+  category: 180,
+  item: 220,
+  planned: 120,
+  actual: 150,
+  variance: 130,
+  due: 130,
+  status: 160,
+  priority: 120
+} as const;
+
+const COLUMN_FLEX_VALUES: Record<SmartBudgetingColumnKey, string> = {
+  category: '1.4fr',
+  item: '2fr',
+  planned: '1fr',
+  actual: '1.1fr',
+  variance: '1fr',
+  due: '0.9fr',
+  status: '1.1fr',
+  priority: '0.8fr'
+} as const;
+
+const formatColumnWidth = (column: SmartBudgetingColumnKey, width: number) => {
+  const minWidth = COLUMN_MIN_WIDTHS[column];
+  const flexValue = COLUMN_FLEX_VALUES[column];
+  const safeWidth = Math.max(minWidth, Math.round(width));
+  return `minmax(${safeWidth}px, ${flexValue})`;
+};
+
+const DEFAULT_COLUMN_WIDTHS = COLUMN_KEYS.reduce<Record<SmartBudgetingColumnKey, string>>((accumulator, column) => {
+  accumulator[column] = formatColumnWidth(column, COLUMN_MIN_WIDTHS[column]);
+  return accumulator;
+}, {} as Record<SmartBudgetingColumnKey, string>);
+
+export const SMART_BUDGETING_COLUMN_MIN_WIDTHS: Readonly<Record<SmartBudgetingColumnKey, number>> =
+  COLUMN_MIN_WIDTHS;
+
 const DEFAULT_COLUMN_PREFERENCES: ColumnPreferences = {
-  order: ['category', 'item', 'planned', 'actual', 'variance', 'due', 'status', 'priority'],
+  order: [...COLUMN_KEYS],
   visible: {
     category: true,
     item: true,
@@ -100,16 +148,7 @@ const DEFAULT_COLUMN_PREFERENCES: ColumnPreferences = {
     status: true,
     priority: true
   },
-  widths: {
-    category: 'minmax(180px,1.4fr)',
-    item: 'minmax(220px,2fr)',
-    planned: 'minmax(120px,1fr)',
-    actual: 'minmax(150px,1.1fr)',
-    variance: 'minmax(130px,1fr)',
-    due: 'minmax(130px,0.9fr)',
-    status: 'minmax(160px,1.1fr)',
-    priority: 'minmax(120px,0.8fr)'
-  }
+  widths: { ...DEFAULT_COLUMN_WIDTHS }
 } as const satisfies ColumnPreferences;
 
 function generateEntryId() {
@@ -181,10 +220,10 @@ export function useSmartBudgetingController() {
     });
   }, []);
 
-  const setColumnWidth = useCallback((column: SmartBudgetingColumnKey, width: string) => {
+  const setColumnWidth = useCallback((column: SmartBudgetingColumnKey, width: number) => {
     setColumnPreferences((previous) => ({
       ...previous,
-      widths: { ...previous.widths, [column]: width || previous.widths[column] }
+      widths: { ...previous.widths, [column]: formatColumnWidth(column, width) }
     }));
   }, []);
 

--- a/src/features/smart-budgeting/organisms/CategoryNavigator.tsx
+++ b/src/features/smart-budgeting/organisms/CategoryNavigator.tsx
@@ -1,5 +1,5 @@
-import { Fragment } from 'react';
-import type { JSX } from 'react';
+import { Fragment, useCallback, useEffect, useRef } from 'react';
+import type { JSX, PointerEvent as ReactPointerEvent } from 'react';
 import { PlannedExpenseItemCard } from '../molecules/PlannedExpenseItemCard';
 import type {
   CategoryNode,
@@ -7,6 +7,7 @@ import type {
   SmartBudgetingColumnKey,
   SmartBudgetingController
 } from '../hooks/useSmartBudgetingController';
+import { SMART_BUDGETING_COLUMN_MIN_WIDTHS } from '../hooks/useSmartBudgetingController';
 
 const CalendarIcon = ({ className = 'h-4 w-4' }: { className?: string }): JSX.Element => (
   <svg viewBox="0 0 20 20" className={className} aria-hidden>
@@ -46,7 +47,69 @@ export function CategoryNavigator({ categories, editing, table, utils }: Categor
     hasNavigatorResults,
     renderedCategories
   } = categories;
-  const { visibleColumns, gridTemplateColumns } = table;
+  const { visibleColumns, gridTemplateColumns, setColumnWidth } = table;
+  const headerRefs = useRef<Partial<Record<SmartBudgetingColumnKey, HTMLDivElement | null>>>({});
+  const activeResizeRef = useRef<{ column: SmartBudgetingColumnKey; cleanup: () => void } | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (activeResizeRef.current) {
+        activeResizeRef.current.cleanup();
+        activeResizeRef.current = null;
+      }
+    };
+  }, []);
+
+  const handleResizeStart = useCallback(
+    (column: SmartBudgetingColumnKey, event: ReactPointerEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      const headerElement = headerRefs.current[column];
+      if (!headerElement) {
+        return;
+      }
+
+      const startWidth = headerElement.getBoundingClientRect().width;
+      const startX = event.clientX;
+      const minWidth = SMART_BUDGETING_COLUMN_MIN_WIDTHS[column] ?? 120;
+
+      const handlePointerMove = (moveEvent: PointerEvent) => {
+        const delta = moveEvent.clientX - startX;
+        const nextWidth = Math.max(minWidth, Math.round(startWidth + delta));
+        setColumnWidth(column, nextWidth);
+      };
+
+      const handlePointerUp = () => {
+        window.removeEventListener('pointermove', handlePointerMove);
+        window.removeEventListener('pointerup', handlePointerUp);
+        document.body.style.cursor = '';
+        activeResizeRef.current = null;
+      };
+
+      activeResizeRef.current?.cleanup();
+      document.body.style.cursor = 'col-resize';
+      window.addEventListener('pointermove', handlePointerMove);
+      window.addEventListener('pointerup', handlePointerUp, { once: true });
+      activeResizeRef.current = {
+        column,
+        cleanup: () => {
+          window.removeEventListener('pointermove', handlePointerMove);
+          window.removeEventListener('pointerup', handlePointerUp);
+          document.body.style.cursor = '';
+        }
+      };
+    },
+    [setColumnWidth]
+  );
+
+  const handleResetWidth = useCallback(
+    (column: SmartBudgetingColumnKey) => {
+      const defaultWidth = SMART_BUDGETING_COLUMN_MIN_WIDTHS[column] ?? 120;
+      setColumnWidth(column, defaultWidth);
+    },
+    [setColumnWidth]
+  );
   const columnLabels: Record<SmartBudgetingColumnKey, string> = {
     category: 'Category',
     item: 'Item',
@@ -358,11 +421,40 @@ export function CategoryNavigator({ categories, editing, table, utils }: Categor
                     className="grid items-center gap-4 border-b border-slate-800/80 bg-slate-950 px-4 py-3 text-[11px] font-semibold uppercase tracking-wide text-slate-400"
                     style={{ gridTemplateColumns }}
                   >
-                    {visibleColumns.map((column) => (
-                      <span key={`header-${column}`} className={headerAlignment[column] ?? 'text-left'}>
-                        {columnLabels[column]}
-                      </span>
-                    ))}
+                    {visibleColumns.map((column, index) => {
+                      const isLastColumn = index === visibleColumns.length - 1;
+                      return (
+                        <div
+                          key={`header-${column}`}
+                          ref={(node) => {
+                            if (node) {
+                              headerRefs.current[column] = node;
+                            } else {
+                              delete headerRefs.current[column];
+                            }
+                          }}
+                          onDoubleClick={() => handleResetWidth(column)}
+                          className={`group relative flex h-full items-center ${headerAlignment[column] ?? 'text-left'}`}
+                        >
+                          <span className="truncate pr-2">{columnLabels[column]}</span>
+                          {!isLastColumn && (
+                            <div
+                              role="separator"
+                              aria-orientation="vertical"
+                              aria-label={`Resize ${columnLabels[column]} column`}
+                              tabIndex={-1}
+                              onPointerDown={(event) => handleResizeStart(column, event)}
+                              className="absolute right-[-6px] top-0 h-full w-3 cursor-col-resize touch-none"
+                            >
+                              <span
+                                aria-hidden
+                                className="pointer-events-none absolute right-1 top-1/2 h-6 w-px -translate-y-1/2 rounded-full bg-slate-800 transition group-hover:bg-accent/60"
+                              />
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })}
                   </div>
                   <div>{categorySections}</div>
                 </div>


### PR DESCRIPTION
## Summary
- add shared column width metadata to the smart budgeting controller so grid tracks adapt to numeric widths
- update the smart budgeting column width setter to format responsive min/max tracks
- add resize handles to the category navigator headers so budgeting columns can be flexibly resized and reset

## Testing
- npm run lint *(fails: ESLint configuration missing in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68e29b44a8c0832c82b1e88b1159a84b