### PR TITLE
Simplify smart budgeting table view

### DIFF
--- a/src/features/smart-budgeting/hooks/useSmartBudgetingController.tsx
+++ b/src/features/smart-budgeting/hooks/useSmartBudgetingController.tsx
@@ -40,8 +40,6 @@ const PRIORITY_OPTIONS: Array<{ value: PlannedExpenseItem['priority']; label: st
   { value: 'low', label: 'Low priority' }
 ];
 
-const PRIORITY_ORDER: PlannedExpenseItem['priority'][] = ['high', 'medium', 'low'];
-
 const PRIORITY_TOKEN_STYLES: Record<PlannedExpenseItem['priority'], { label: string; badgeClass: string }> = {
   high: { label: 'High priority', badgeClass: 'bg-danger/20 text-danger' },
   medium: { label: 'Medium priority', badgeClass: 'bg-warning/20 text-warning' },
@@ -391,7 +389,6 @@ export function useSmartBudgetingController() {
   const [quickActualDrafts, setQuickActualDrafts] = useState<Record<string, string>>({});
   const [quickActualSavingId, setQuickActualSavingId] = useState<string | null>(null);
   const [navigatorFilter, setNavigatorFilter] = useState<'all' | PlannedExpenseSpendingHealth>('all');
-  const [navigatorView, setNavigatorView] = useState<'category' | 'priority'>('category');
   const [categorySearchTerm, setCategorySearchTerm] = useState('');
   const [focusedCategoryId, setFocusedCategoryId] = useState<string | null>(null);
   const [focusedDetailId, setFocusedDetailId] = useState<string | null>(null);
@@ -405,11 +402,6 @@ export function useSmartBudgetingController() {
     { key: 'over', label: 'Overspending' },
     { key: 'under', label: 'Under budget' },
     { key: 'not-spent', label: 'Awaiting spend' }
-  ];
-
-  const navigatorViewOptions: Array<{ key: 'category' | 'priority'; label: string }> = [
-    { key: 'category', label: 'Category view' },
-    { key: 'priority', label: 'Priority view' }
   ];
 
   const normalisedSearchTerm = categorySearchTerm.trim().toLowerCase();
@@ -699,55 +691,6 @@ export function useSmartBudgetingController() {
     setBudgetDraft(typeof budgetValue === 'number' && !Number.isNaN(budgetValue) ? String(budgetValue) : '');
   }, [focusedCategoryId, categoryLookup, viewMode]);
 
-  const filteredPriorityDetails = useMemo(() => {
-    return plannedExpenseDetails.filter((detail) => {
-      if (activeCategoryIds && !activeCategoryIds.has(detail.item.categoryId)) {
-        return false;
-      }
-      const matchesFilter = navigatorFilter === 'all' || detail.status === navigatorFilter;
-      if (!matchesFilter) {
-        return false;
-      }
-      if (normalisedSearchTerm === '') {
-        return true;
-      }
-      const categoryName = categoryLookup.get(detail.item.categoryId)?.name?.toLowerCase() ?? 'uncategorised';
-      return (
-        detail.item.name.toLowerCase().includes(normalisedSearchTerm) || categoryName.includes(normalisedSearchTerm)
-      );
-    });
-  }, [
-    plannedExpenseDetails,
-    activeCategoryIds,
-    navigatorFilter,
-    normalisedSearchTerm,
-    categoryLookup
-  ]);
-
-  const priorityGroups = useMemo(() => {
-    const groups: Record<PlannedExpenseItem['priority'], PlannedExpenseDetail[]> = {
-      high: [],
-      medium: [],
-      low: []
-    };
-    const timeForDetail = (detail: PlannedExpenseDetail) =>
-      detail.item.dueDate ? new Date(detail.item.dueDate).getTime() : Number.POSITIVE_INFINITY;
-    filteredPriorityDetails.forEach((detail) => {
-      const priority = detail.priority ?? 'medium';
-      groups[priority].push(detail);
-    });
-    PRIORITY_ORDER.forEach((priority) => {
-      groups[priority].sort((a, b) => {
-        const dueComparison = timeForDetail(a) - timeForDetail(b);
-        if (dueComparison !== 0) {
-          return dueComparison;
-        }
-        return a.item.name.localeCompare(b.item.name);
-      });
-    });
-    return groups;
-  }, [filteredPriorityDetails]);
-
   const overallSummary = useMemo(() => {
     const planned = totalsForAll.totalPlanned;
     const actual = totalsForAll.actualTotal;
@@ -974,7 +917,6 @@ export function useSmartBudgetingController() {
 
   const handleResetFilters = () => {
     setNavigatorFilter('all');
-    setNavigatorView('category');
     setCategorySearchTerm('');
     setSelectedCategoryId('all');
   };
@@ -1151,7 +1093,6 @@ export function useSmartBudgetingController() {
   const handleFocusDetail = (detail: PlannedExpenseDetail) => {
     setNavigatorFilter('all');
     setCategorySearchTerm('');
-    setNavigatorView('category');
     setFocusedCategoryId(detail.item.categoryId);
     setFocusedDetailId(detail.item.id);
     if (activeCategoryIds && !activeCategoryIds.has(detail.item.categoryId)) {
@@ -1176,8 +1117,7 @@ export function useSmartBudgetingController() {
       : 'over';
   const selectedStatusToken = SPENDING_BADGE_STYLES[selectedCategoryStatus];
   const baselineLabel = viewMode === 'monthly' ? 'Monthly baseline (₹)' : 'Yearly baseline (₹)';
-  const hasNavigatorResults =
-    visibleNavigatorDetails.length > 0 || filteredPriorityDetails.length > 0;
+  const hasNavigatorResults = visibleNavigatorDetails.length > 0;
 
   const tableConfig = useMemo(
     () => ({
@@ -1319,8 +1259,8 @@ export function useSmartBudgetingController() {
       views: {
         smartBudgetingTable: {
           period: tablePeriod,
-          rows: plannedExpenseDetails.map((detail) => detail.item.id),
-          visibleDetailIds: plannedExpenseDetails.map((detail) => detail.item.id),
+          rows: visibleNavigatorDetails.map((detail) => detail.item.id),
+          visibleDetailIds: visibleNavigatorDetails.map((detail) => detail.item.id),
           rowMetadata: smartBudgetingRowMetadata,
           columnOrder: [...columnPreferences.order]
         }
@@ -1335,7 +1275,6 @@ export function useSmartBudgetingController() {
           },
           filters: {
             navigatorFilter,
-            navigatorView,
             searchTerm: categorySearchTerm,
             selectedCategoryId
           },
@@ -1376,9 +1315,9 @@ export function useSmartBudgetingController() {
     isAddExpenseDialogOpen,
     itemsByCategory,
     navigatorFilter,
-    navigatorView,
     plannedEntries,
     plannedExpenseDetails,
+    visibleNavigatorDetails,
     categoryLookup,
     quickActualDrafts,
     selectedCategoryId,
@@ -1443,14 +1382,9 @@ export function useSmartBudgetingController() {
       navigatorFilter,
       setNavigatorFilter,
       navigatorFilterOptions,
-      navigatorView,
-      setNavigatorView,
-      navigatorViewOptions,
       categorySearchTerm,
       setCategorySearchTerm,
       normalisedSearchTerm,
-      priorityGroups,
-      visibleCategoryDetails: plannedExpenseDetails,
       focusedCategoryId,
       setFocusedCategoryId,
       focusedDetailId,

--- a/src/features/smart-budgeting/organisms/CategoryNavigator.tsx
+++ b/src/features/smart-budgeting/organisms/CategoryNavigator.tsx
@@ -14,13 +14,7 @@ interface CategoryNavigatorProps {
 }
 
 export function CategoryNavigator({ categories, editing, table, utils }: CategoryNavigatorProps) {
-  const {
-    visibleNavigatorDetails,
-    navigatorView,
-    priorityGroups,
-    hasNavigatorResults,
-    focusedDetailId
-  } = categories;
+  const { visibleNavigatorDetails, hasNavigatorResults, focusedDetailId } = categories;
   const { visibleColumns, gridTemplateColumns } = table;
 
   const columnLabels: Record<SmartBudgetingColumnKey, string> = {
@@ -47,14 +41,14 @@ export function CategoryNavigator({ categories, editing, table, utils }: Categor
   const itemRefs = useRef(new Map<string, HTMLDivElement>());
 
   useEffect(() => {
-    if (navigatorView !== 'category' || !focusedDetailId) {
+    if (!focusedDetailId) {
       return;
     }
     const element = itemRefs.current.get(focusedDetailId);
     if (element) {
       element.scrollIntoView({ behavior: 'smooth', block: 'center' });
     }
-  }, [focusedDetailId, navigatorView, visibleNavigatorDetails]);
+  }, [focusedDetailId, visibleNavigatorDetails]);
 
   const captureRowRef = (detailId: string) => (element: HTMLDivElement | null) => {
     if (element) {
@@ -106,40 +100,6 @@ export function CategoryNavigator({ categories, editing, table, utils }: Categor
     </div>
   );
 
-  const prioritySection = (
-    <div className="space-y-4">
-      {(['high', 'medium', 'low'] as const).map((priority) => {
-        const list = priorityGroups[priority];
-        return (
-          <div key={priority} className="rounded-lg border border-slate-800 bg-slate-950/50">
-            <div className="flex items-center justify-between border-b border-slate-800 px-4 py-3 text-xs text-slate-300">
-              <span className="font-semibold uppercase tracking-wide">{utils.PRIORITY_TOKEN_STYLES[priority].label}</span>
-              <span className="rounded-full bg-slate-800/60 px-2 py-0.5 text-[10px] text-slate-400">{list.length} items</span>
-            </div>
-            {list.length > 0 ? (
-              <div className="divide-y divide-slate-800">
-                {list.map((detail) => (
-                  <PlannedExpenseItemCard
-                    key={detail.item.id}
-                    detail={detail}
-                    depth={0}
-                    categories={categories}
-                    editing={editing}
-                    table={table}
-                    utils={utils}
-                    isFocused={focusedDetailId === detail.item.id}
-                  />
-                ))}
-              </div>
-            ) : (
-              <p className="px-4 py-3 text-xs text-slate-500">No items captured for this priority.</p>
-            )}
-          </div>
-        );
-      })}
-    </div>
-  );
-
   if (!hasNavigatorResults) {
     return (
       <div className="rounded-lg border border-slate-800 bg-slate-950/70 p-6 text-center text-sm text-slate-500">
@@ -148,5 +108,5 @@ export function CategoryNavigator({ categories, editing, table, utils }: Categor
     );
   }
 
-  return <section className="space-y-4">{navigatorView === 'category' ? categoryView : prioritySection}</section>;
+  return <section>{categoryView}</section>;
 }

--- a/src/features/smart-budgeting/organisms/NavigatorFilters.tsx
+++ b/src/features/smart-budgeting/organisms/NavigatorFilters.tsx
@@ -50,31 +50,6 @@ const statusIcons: Record<'all' | 'over' | 'under' | 'not-spent', JSX.Element> =
   )
 };
 
-const viewIcons: Record<'category' | 'priority', JSX.Element> = {
-  category: (
-    <svg viewBox="0 0 20 20" className="h-4 w-4" aria-hidden>
-      <path
-        d="M4 5.5A1.5 1.5 0 0 1 5.5 4H9l2 2.5h3.5A1.5 1.5 0 0 1 16 8v6.5A1.5 1.5 0 0 1 14.5 16h-9A1.5 1.5 0 0 1 4 14.5Z"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.4"
-        strokeLinejoin="round"
-      />
-    </svg>
-  ),
-  priority: (
-    <svg viewBox="0 0 20 20" className="h-4 w-4" aria-hidden>
-      <path
-        d="m10 3 1.9 3.8 4.1.6-3 3 0.7 4.3L10 12.8 6.3 14.7 7 10.4l-3-3 4.1-.6Z"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.4"
-        strokeLinejoin="round"
-      />
-    </svg>
-  )
-};
-
 const searchIcon = (
   <svg viewBox="0 0 20 20" className="h-4 w-4" aria-hidden>
     <circle cx="9" cy="9" r="6" fill="none" stroke="currentColor" strokeWidth="1.4" />
@@ -101,9 +76,6 @@ export function NavigatorFilters({ categories, table, onOpenDialog }: NavigatorF
     navigatorFilter,
     setNavigatorFilter,
     navigatorFilterOptions,
-    navigatorView,
-    setNavigatorView,
-    navigatorViewOptions,
     categorySearchTerm,
     setCategorySearchTerm,
     handleResetFilters
@@ -135,24 +107,6 @@ export function NavigatorFilters({ categories, table, onOpenDialog }: NavigatorF
               }`}
             >
               <span className="text-current [&>svg]:h-4 [&>svg]:w-4">{statusIcons[option.key]}</span>
-              <span className="whitespace-nowrap">{option.label}</span>
-            </button>
-          ))}
-        </div>
-      </div>
-      <div className="flex min-w-[200px] flex-col gap-2">
-        <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">Navigator view</span>
-        <div className="flex flex-wrap gap-2">
-          {navigatorViewOptions.map((option) => (
-            <button
-              key={option.key}
-              type="button"
-              onClick={() => setNavigatorView(option.key)}
-              className={`flex items-center gap-2 rounded-full px-3 py-1 text-[11px] font-semibold transition ${
-                navigatorView === option.key ? 'bg-accent text-slate-900' : 'bg-slate-800 text-slate-300 hover:bg-slate-700'
-              }`}
-            >
-              <span className="text-current [&>svg]:h-4 [&>svg]:w-4">{viewIcons[option.key]}</span>
               <span className="whitespace-nowrap">{option.label}</span>
             </button>
           ))}


### PR DESCRIPTION
## Summary
- flatten the smart budgeting navigator to a single category-based table and drop the priority accordion view
- align the smart budgeting table schema with the visible navigator rows so the normalized store stays in sync
- simplify navigator filters by removing the unused view toggle controls

## Testing
- npm run lint *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68e29d6daec4832caa0873dd16b68764