### PR TITLE
Add flexible DataTable component

### DIFF
--- a/src/components/molecules/DataTable.tsx
+++ b/src/components/molecules/DataTable.tsx
@@ -1,0 +1,149 @@
+import type { ReactNode } from 'react';
+import { cn } from '../../utils/cn';
+
+type DataTableAlignment = 'left' | 'center' | 'right';
+
+export interface DataTableColumn<T> {
+  id: string;
+  header: ReactNode;
+  render: (row: T, rowIndex: number) => ReactNode;
+  align?: DataTableAlignment;
+  width?: string;
+  minWidth?: string;
+  headerClassName?: string;
+  cellClassName?: string | ((row: T, rowIndex: number) => string | false | null | undefined);
+}
+
+export interface DataTableProps<T> {
+  data: T[];
+  columns: Array<DataTableColumn<T>>;
+  keyExtractor?: (row: T, rowIndex: number) => string | number;
+  emptyState?: ReactNode;
+  className?: string;
+  rowClassName?: string | ((row: T, rowIndex: number) => string | false | null | undefined);
+}
+
+const ALIGNMENT_CLASSNAME_MAP: Record<DataTableAlignment, string> = {
+  left: 'text-left',
+  center: 'text-center',
+  right: 'text-right'
+};
+
+function resolveColumnTemplate<T>(column: DataTableColumn<T>) {
+  if (column.width && column.minWidth) {
+    return `minmax(${column.minWidth}, ${column.width})`;
+  }
+
+  if (column.width) {
+    return column.width;
+  }
+
+  if (column.minWidth) {
+    return `minmax(${column.minWidth}, 1fr)`;
+  }
+
+  return 'minmax(0, 1fr)';
+}
+
+function resolveRowClassName<T>(
+  rowClassName: DataTableProps<T>['rowClassName'],
+  row: T,
+  rowIndex: number
+) {
+  if (typeof rowClassName === 'function') {
+    return rowClassName(row, rowIndex);
+  }
+
+  return rowClassName;
+}
+
+function resolveCellClassName<T>(
+  column: DataTableColumn<T>,
+  row: T,
+  rowIndex: number
+) {
+  if (typeof column.cellClassName === 'function') {
+    return column.cellClassName(row, rowIndex);
+  }
+
+  return column.cellClassName;
+}
+
+export function DataTable<T>({
+  data,
+  columns,
+  keyExtractor,
+  emptyState,
+  className,
+  rowClassName
+}: DataTableProps<T>) {
+  const columnTemplate = columns.map((column) => resolveColumnTemplate(column)).join(' ');
+
+  return (
+    <div className={cn('overflow-x-auto', className)}>
+      <div role="table" className="min-w-full divide-y divide-slate-800 text-sm">
+        <div role="rowgroup" className="bg-slate-900/80 text-xs uppercase text-slate-400">
+          <div
+            role="row"
+            className="grid gap-x-6 px-4 py-3"
+            style={{ gridTemplateColumns: columnTemplate }}
+          >
+            {columns.map((column) => (
+              <div
+                key={column.id}
+                role="columnheader"
+                className={cn('font-semibold', ALIGNMENT_CLASSNAME_MAP[column.align ?? 'left'], column.headerClassName)}
+              >
+                {column.header}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div role="rowgroup" className="divide-y divide-slate-800">
+          {data.map((row, rowIndex) => {
+            const key = keyExtractor ? keyExtractor(row, rowIndex) : rowIndex;
+            const computedRowClassName = resolveRowClassName(rowClassName, row, rowIndex);
+
+            return (
+              <div
+                key={key}
+                role="row"
+                className={cn(
+                  'grid gap-x-6 px-4 py-3 transition-colors hover:bg-slate-800/40',
+                  computedRowClassName
+                )}
+                style={{ gridTemplateColumns: columnTemplate }}
+              >
+                {columns.map((column) => (
+                  <div
+                    key={column.id}
+                    role="cell"
+                    className={cn(
+                      ALIGNMENT_CLASSNAME_MAP[column.align ?? 'left'],
+                      resolveCellClassName(column, row, rowIndex)
+                    )}
+                  >
+                    {column.render(row, rowIndex)}
+                  </div>
+                ))}
+              </div>
+            );
+          })}
+
+          {data.length === 0 && emptyState ? (
+            <div
+              role="row"
+              className="grid gap-x-6 px-4 py-6 text-center text-sm text-slate-500"
+              style={{ gridTemplateColumns: columnTemplate }}
+            >
+              <div role="cell" className="col-span-full">
+                {emptyState}
+              </div>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/organisms/RecentTransactionsTable.tsx
+++ b/src/components/organisms/RecentTransactionsTable.tsx
@@ -1,7 +1,9 @@
 import { format } from 'date-fns';
 import type { Transaction } from '../../types';
+import { cn } from '../../utils/cn';
 import { Card } from '../atoms/Card';
 import { SectionHeading } from '../atoms/SectionHeading';
+import { DataTable, type DataTableColumn } from '../molecules/DataTable';
 
 interface RecentTransactionsTableProps {
   transactions: Transaction[];
@@ -14,41 +16,49 @@ export function RecentTransactionsTable({
   resolveCategoryName,
   formatCurrency
 }: RecentTransactionsTableProps) {
+  const columns: Array<DataTableColumn<Transaction>> = [
+    {
+      id: 'date',
+      header: 'Date',
+      width: 'max-content',
+      render: (txn) => format(new Date(txn.date), 'd MMM')
+    },
+    {
+      id: 'description',
+      header: 'Description',
+      minWidth: '220px',
+      width: '2fr',
+      render: (txn) => txn.description,
+      cellClassName: 'truncate'
+    },
+    {
+      id: 'category',
+      header: 'Category',
+      minWidth: '180px',
+      width: '1fr',
+      render: (txn) => resolveCategoryName(txn.categoryId)
+    },
+    {
+      id: 'amount',
+      header: 'Amount',
+      align: 'right',
+      minWidth: '120px',
+      width: 'max-content',
+      render: (txn) => formatCurrency(txn.amount),
+      cellClassName: (txn) => cn('font-medium', txn.amount < 0 ? 'text-danger' : 'text-success')
+    }
+  ];
+
   return (
     <section>
       <SectionHeading className="mb-3">Recent Transactions</SectionHeading>
       <Card className="border border-slate-800">
-        <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-slate-800 text-sm">
-            <thead className="bg-slate-900/80 text-xs uppercase text-slate-400">
-              <tr>
-                <th className="px-4 py-3 text-left">Date</th>
-                <th className="px-4 py-3 text-left">Description</th>
-                <th className="px-4 py-3 text-left">Category</th>
-                <th className="px-4 py-3 text-right">Amount</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-slate-800">
-              {transactions.map((txn) => (
-                <tr key={txn.id} className="hover:bg-slate-800/40">
-                  <td className="px-4 py-3">{format(new Date(txn.date), 'd MMM')}</td>
-                  <td className="px-4 py-3">{txn.description}</td>
-                  <td className="px-4 py-3">{resolveCategoryName(txn.categoryId)}</td>
-                  <td className={`px-4 py-3 text-right ${txn.amount < 0 ? 'text-danger' : 'text-success'}`}>
-                    {formatCurrency(txn.amount)}
-                  </td>
-                </tr>
-              ))}
-              {transactions.length === 0 ? (
-                <tr>
-                  <td colSpan={4} className="px-4 py-6 text-center text-sm text-slate-500">
-                    No transactions recorded yet.
-                  </td>
-                </tr>
-              ) : null}
-            </tbody>
-          </table>
-        </div>
+        <DataTable
+          data={transactions}
+          columns={columns}
+          keyExtractor={(txn) => txn.id}
+          emptyState="No transactions recorded yet."
+        />
       </Card>
     </section>
   );


### PR DESCRIPTION
## Summary
- add a reusable DataTable component that supports flexible column sizing and configurable alignment
- refactor the recent transactions table to consume the DataTable for improved layout control and styling consistency

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2a2e78510832caac0835ec11ef5b7